### PR TITLE
Adding VEDirect interfacer and sample configuration

### DIFF
--- a/conf/VEDirect.readme.md
+++ b/conf/VEDirect.readme.md
@@ -1,0 +1,55 @@
+#VE Direct interface Victron products#
+
+The VE Direct protocol is as binary/ASCII [protocol](https://www.victronenergy.com/upload/documents/VE.Direct-Protocol.pdf) used by [Victron Energy] to communicate between it's products. For those who don't know, Victron is the leading producer of solar inverters and charge controllers designed for the off grid market.
+
+ With this interfacer now it's possible to interface  data from any VE Direct compatible Victron product with Emon. In this example we use the [BMV 700](https://www.google.rw/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwi14t-MkqfLAhVBExoKHRGeCioQFggbMAA&url=https%3A%2F%2Fwww.victronenergy.com%2Fbattery-monitors%2Fbmv-700&usg=AFQjCNGENUubkSY_HkWGN61NdkP8onXHag&sig2=XjH6HIbtSzwY_kDDKOfsJw), which is a battery monitor. For emon users that have a battery bank, this will allow them to get stats on their batteries very easily.
+
+##Usage and configuration##
+There is a sample vedirect.emonhub.conf file located in this directory.
+This is already preconfigured to talk to a BMV700 that is connect to the emonpi via isolated [USB cable](https://www.victronenergy.com/accessories/ve-direct-to-usb-interface)
+
+Each VE Direct product has it's own source of variables that it delivers. The full list of variables can be found on Victron's github page as [datalist.py](https://github.com/victronenergy/velib_python/blob/master/dbusmonitor.py).
+
+This file isn't necessary, but it's just useful as a reference to see which data codes correspond to which values.
+
+
+
+###Sample interfacer config within emonhub.conf ###
+    # Sample configuration for Victron Product with VEDirect connection over USB
+    # Configuration is for BMV 700
+    [[VEDirect]]
+    Type = EmonHubVEDirectInterfacer
+    [[[init_settings]]]
+    com_port = /dev/ttyUSB0 # Where to find our device
+        com_baud = 19200      # Baud rate needed to decode
+        toextract = SOC,CE,TTG,V,I,Relay,Alarm # These are the fields we wish to extract, explanation can be seen in datalist.py
+        poll_interval = 10 # How often to get data in seconds
+    [[[runtimesettings]]]
+        nodeoffset = 9 #make sure this matches with nodename below
+        pubchannels = ToEmonCMS,
+        subchannels = ToBMV,
+        basetopic = emonhub/
+
+
+### Followed by a  corresponding Node declaration in emonhub.conf###
+In this example our battery monitor will be designated node id 9 
+
+    [[9]]
+    nodename = emonDC
+    firmware =V1_6_emonTxV3_4_DiscreteSampling #not used
+    hardware = emonTx_(NodeID_DIP_Switch1:ON) #not used
+    [[[rx]]]
+       names = SOC,CE,TTG,V,I,Relay,Alarm # Make sure this matches 'toextract' in interfacer
+       datacode = 0 #no need to decode values
+       scales = 0.1,1,1,0.001,1,1,1 # Some scaling necassary
+       units =%,Ah,s,V,A,S,S 
+
+
+With this config in place now you simply need to restart emonhub on our emonpi by ssh'ing into it and typing 
+
+      $>sudo service emonhub restart
+
+If there are any problems you can debug by looking inside /var/emonhub/emonhub.log
+
+Hope that helps
+

--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -73,22 +73,6 @@ loglevel = DEBUG #(default:WARNING)
         senddata = 1
         sendstatus = 1
 
-# Sample configuration for Victron Product with VEDirect connection over USB
-# Configuration is for BMV 700
-#[[VEDirect]]
-#    Type = EmonHubVEDirectInterfacer
-#    [[[init_settings]]]
-#        com_port = /dev/ttyUSB0
-#        com_baud = 19200
-#        toextract = SOC,CE,TTG,V,I,Relay,Alarm # These are the fields we wish to extract
-#        poll_interval = 10                     # More fields can be found in datalist.py
-#    [[[runtimesettings]]]
-#        nodeoffset = 9 #make sure this matches with nodename below
-#        pubchannels = ToEmonCMS,
-#        subchannels = ToBMV,
-#        basetopic = emonhub/
-
-
 #######################################################################
 #######################          Nodes          #######################
 #######################################################################
@@ -144,15 +128,6 @@ loglevel = DEBUG #(default:WARNING)
        datacode = h
        scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p
-#[[9]]
-#    nodename = emonDC
-#    firmware =V1_6_emonTxV3_4_DiscreteSampling
-#    hardware = emonTx_(NodeID_DIP_Switch1:ON)
-#    [[[rx]]]
-#       names = SOC,CE,TTG,V,I,Relay,Alarm # Make sure this matches 'toextract' in interfacer
-#       datacode = 0
-#       scales = 0.1,1,1,0.001,1,1,1
-#       units =%,Ah,s,V,A,S,S                   #FirmwareV1.6
 
 [[19]]
    nodename = emonth1

--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -73,6 +73,22 @@ loglevel = DEBUG #(default:WARNING)
         senddata = 1
         sendstatus = 1
 
+# Sample configuration for Victron Product with VEDirect connection over USB
+# Configuration is for BMV 700
+#[[VEDirect]]
+#    Type = EmonHubVEDirectInterfacer
+#    [[[init_settings]]]
+#        com_port = /dev/ttyUSB0
+#        com_baud = 19200
+#        toextract = SOC,CE,TTG,V,I,Relay,Alarm # These are the fields we wish to extract
+#        poll_interval = 10                     # More fields can be found in datalist.py
+#    [[[runtimesettings]]]
+#        nodeoffset = 9 #make sure this matches with nodename below
+#        pubchannels = ToEmonCMS,
+#        subchannels = ToBMV,
+#        basetopic = emonhub/
+
+
 #######################################################################
 #######################          Nodes          #######################
 #######################################################################
@@ -128,6 +144,15 @@ loglevel = DEBUG #(default:WARNING)
        datacode = h
        scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p
+#[[9]]
+#    nodename = emonDC
+#    firmware =V1_6_emonTxV3_4_DiscreteSampling
+#    hardware = emonTx_(NodeID_DIP_Switch1:ON)
+#    [[[rx]]]
+#       names = SOC,CE,TTG,V,I,Relay,Alarm # Make sure this matches 'toextract' in interfacer
+#       datacode = 0
+#       scales = 0.1,1,1,0.001,1,1,1
+#       units =%,Ah,s,V,A,S,S                   #FirmwareV1.6
 
 [[19]]
    nodename = emonth1

--- a/conf/vedirect.emonhub.conf
+++ b/conf/vedirect.emonhub.conf
@@ -23,55 +23,22 @@ loglevel = DEBUG #(default:WARNING)
 
 [interfacers]
 ### This interfacer manages the RFM12Pi/RFM69Pi/emonPi module
-[[RFM2Pi]]
-    Type = EmonHubJeeInterfacer
+
+# Sample configuration for Victron Product with VEDirect connection over USB
+# Configuration is for BMV 700
+[[VEDirect]]
+    Type = EmonHubVEDirectInterfacer
     [[[init_settings]]]
-        com_port = /dev/ttyAMA0
-        com_baud = 38400                      # 9600 for old RFM12Pi modules
+        com_port = /dev/ttyUSB0
+        com_baud = 19200
+        toextract = SOC,CE,TTG,V,I,Relay,Alarm # These are the fields we wish to extract
+        poll_interval = 10                     # More fields can be found in datalist.py
     [[[runtimesettings]]]
+        nodeoffset = 9 #make sure this matches with nodename below
         pubchannels = ToEmonCMS,
-        subchannels = ToRFM12,
+        subchannels = ToBMV,
+        basetopic = emonhub/
 
-        group = 210
-        frequency = 433
-        baseid = 5                              # emonPi / emonBase nodeID
-        quiet = false                           # Report incomplete RF packets (no implemented on emonPi)
-        calibration = 230V                      # (UK/EU: 230V, US: 110V)
-        # interval =  0                         # Interval to transmit time to emonGLCD (seconds)
-
-[[MQTT]]
-
-    Type = EmonHubMqttInterfacer
-    [[[init_settings]]]
-        mqtt_host = 127.0.0.1
-        mqtt_port = 1883
-        mqtt_user = ''
-        mqtt_passwd = ''
-
-    [[[runtimesettings]]]
-        pubchannels = ToRFM12,
-        subchannels = ToEmonCMS,
-
-        # emonhub/rx/10/values format
-        # Use with emoncms Nodes module
-        node_format_enable = 1
-        node_format_basetopic = emonhub/
-
-        # emon/emontx/power1 format - use with Emoncms MQTT input
-        # http://github.com/emoncms/emoncms/blob/master/docs/RaspberryPi/MQTT.md
-        nodevar_format_enable = 1
-        nodevar_format_basetopic = emon/
-
-[[emoncmsorg]]
-    Type = EmonHubEmoncmsHTTPInterfacer
-    [[[init_settings]]]
-    [[[runtimesettings]]]
-        pubchannels = ToRFM12,
-        subchannels = ToEmonCMS,
-        url = https://emoncms.org
-        apikey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        senddata = 1
-        sendstatus = 1
 
 #######################################################################
 #######################          Nodes          #######################
@@ -81,113 +48,13 @@ loglevel = DEBUG #(default:WARNING)
 
 ## See config user guide: http://github.com/openenergymonitor/emonhub/blob/master/configuration.md
 
-[[5]]
-    nodename = emonpi
-    [[[rx]]]
-        names = power1,power2,power1pluspower2,vrms,t1,t2,t3,t4,t5,t6,pulsecount
-        datacodes = h, h, h, h, h, h, h, h, h, h, L
-        scales = 1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-        units = W,W,W,V,C,C,C,C,C,C,p
-
-[[6]]
-    nodename = emontxshield
-    [[[rx]]]
-       names = power1, power2, power3, power4, vrms
-       datacode = h
-       scales = 1,1,1,1,0.01
-       units =W,W,W,W,V
-
-[[7]]
-   nodename = emontx4
-   [[[rx]]]
-      names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-      datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-      scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-      units =W,W,W,W,V,C,C,C,C,C,C,p
-
-[[8]]
-    nodename = emontx3
-    [[[rx]]]
-       names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
 
 [[9]]
-   nodename = emontx2
-   [[[rx]]]
-      names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-      datacode = h
-      scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-      units =W,W,W,W,V,C,C,C,C,C,C,p
-
-[[10]]
-    nodename = emontx1
+    nodename = emonDC
+    firmware =V1_6_emonTxV3_4_DiscreteSampling
+    hardware = emonTx_(NodeID_DIP_Switch1:ON)
     [[[rx]]]
-       names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h
-       scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
-
-[[19]]
-   nodename = emonth1
-   [[[rx]]]
-      names = temperature, external temperature, humidity, battery
-      datacode = h
-      scales = 0.1,0.1,0.1,0.1
-      units = C,C,%,V
-
-[[20]]
-   nodename = emonth2
-   [[[rx]]]
-      names = temperature, external temperature, humidity, battery
-      datacode = h
-      scales = 0.1,0.1,0.1,0.1
-      units = C,C,%,V
-
-[[21]]
-   nodename = emonth3
-   [[[rx]]]
-      names = temperature, external temperature, humidity, battery
-      datacode = h
-      scales = 0.1,0.1,0.1,0.1
-      units = C,C,%,V
-
-[[22]]
-   nodename = emonth4
-   [[[rx]]]
-      names = temperature, external temperature, humidity, battery
-      datacode = h
-      scales = 0.1,0.1,0.1,0.1
-      units = C,C,%,V
-[[23]]
-    nodename = emonth5
-    [[[rx]]]
-       names = temperature, external temperature, humidity, battery, pulsecount
-       datacodes = h,h,h,h,L
-       scales = 0.1,0.1,0.1,0.1,1
-       units = C,C,%,V,p
-
-[[24]]
-    nodename = emonth6
-    [[[rx]]]
-       names = temperature, external temperature, humidity, battery, pulsecount
-       datacodes = h,h,h,h,L
-       scales = 0.1,0.1,0.1,0.1,1
-       units = C,C,%,V,p
-
-[[25]]
-    nodename = emonth7
-    [[[rx]]]
-       names = temperature, external temperature, humidity, battery, pulsecount
-       datacodes = h,h,h,h,L
-       scales = 0.1,0.1,0.1,0.1,1
-       units = C,C,%,V,p
-
-[[26]]
-    nodename = emonth8
-    [[[rx]]]
-       names = temperature, external temperature, humidity, battery, pulsecount
-       datacodes = h,h,h,h,L
-       scales = 0.1,0.1,0.1,0.1,1
-       units = C,C,%,V,p
+       names = SOC,CE,TTG,V,I,Relay,Alarm # Make sure this matches 'toextract' in interfacer
+       datacode = 0
+       scales = 0.1,1,1,0.001,1,1,1
+       units =%,Ah,s,V,A,S,S                   #FirmwareV1.6

--- a/conf/vedirect.emonhub.conf
+++ b/conf/vedirect.emonhub.conf
@@ -1,0 +1,193 @@
+#######################################################################
+#######################      emonhub.conf     #########################
+#######################################################################
+
+## **LEGACY CONFIG: For use with 17thJune2015 emonPi/emonBase image and older **
+## (check image version by looking for file in /boot)
+## Uses old CSV MQTT topic structure compatible with Emoncms Nodes
+## Does not use MQTT server authentication
+
+### emonHub configuration file, for info see documentation:
+### http://github.com/openenergymonitor/emonhub/blob/master/configuration.md
+#######################################################################
+#######################    emonHub  settings    #######################
+#######################################################################
+
+[hub]
+### loglevel must be one of DEBUG, INFO, WARNING, ERROR, and CRITICAL
+loglevel = DEBUG #(default:WARNING)
+
+#######################################################################
+#######################       Interfacers       #######################
+#######################################################################
+
+[interfacers]
+### This interfacer manages the RFM12Pi/RFM69Pi/emonPi module
+[[RFM2Pi]]
+    Type = EmonHubJeeInterfacer
+    [[[init_settings]]]
+        com_port = /dev/ttyAMA0
+        com_baud = 38400                      # 9600 for old RFM12Pi modules
+    [[[runtimesettings]]]
+        pubchannels = ToEmonCMS,
+        subchannels = ToRFM12,
+
+        group = 210
+        frequency = 433
+        baseid = 5                              # emonPi / emonBase nodeID
+        quiet = false                           # Report incomplete RF packets (no implemented on emonPi)
+        calibration = 230V                      # (UK/EU: 230V, US: 110V)
+        # interval =  0                         # Interval to transmit time to emonGLCD (seconds)
+
+[[MQTT]]
+
+    Type = EmonHubMqttInterfacer
+    [[[init_settings]]]
+        mqtt_host = 127.0.0.1
+        mqtt_port = 1883
+        mqtt_user = ''
+        mqtt_passwd = ''
+
+    [[[runtimesettings]]]
+        pubchannels = ToRFM12,
+        subchannels = ToEmonCMS,
+
+        # emonhub/rx/10/values format
+        # Use with emoncms Nodes module
+        node_format_enable = 1
+        node_format_basetopic = emonhub/
+
+        # emon/emontx/power1 format - use with Emoncms MQTT input
+        # http://github.com/emoncms/emoncms/blob/master/docs/RaspberryPi/MQTT.md
+        nodevar_format_enable = 1
+        nodevar_format_basetopic = emon/
+
+[[emoncmsorg]]
+    Type = EmonHubEmoncmsHTTPInterfacer
+    [[[init_settings]]]
+    [[[runtimesettings]]]
+        pubchannels = ToRFM12,
+        subchannels = ToEmonCMS,
+        url = https://emoncms.org
+        apikey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        senddata = 1
+        sendstatus = 1
+
+#######################################################################
+#######################          Nodes          #######################
+#######################################################################
+
+[nodes]
+
+## See config user guide: http://github.com/openenergymonitor/emonhub/blob/master/configuration.md
+
+[[5]]
+    nodename = emonpi
+    [[[rx]]]
+        names = power1,power2,power1pluspower2,vrms,t1,t2,t3,t4,t5,t6,pulsecount
+        datacodes = h, h, h, h, h, h, h, h, h, h, L
+        scales = 1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+        units = W,W,W,V,C,C,C,C,C,C,p
+
+[[6]]
+    nodename = emontxshield
+    [[[rx]]]
+       names = power1, power2, power3, power4, vrms
+       datacode = h
+       scales = 1,1,1,1,0.01
+       units =W,W,W,W,V
+
+[[7]]
+   nodename = emontx4
+   [[[rx]]]
+      names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+      datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+      scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
+      units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[8]]
+    nodename = emontx3
+    [[[rx]]]
+       names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[9]]
+   nodename = emontx2
+   [[[rx]]]
+      names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+      datacode = h
+      scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
+      units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[10]]
+    nodename = emontx1
+    [[[rx]]]
+       names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacode = h
+       scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[19]]
+   nodename = emonth1
+   [[[rx]]]
+      names = temperature, external temperature, humidity, battery
+      datacode = h
+      scales = 0.1,0.1,0.1,0.1
+      units = C,C,%,V
+
+[[20]]
+   nodename = emonth2
+   [[[rx]]]
+      names = temperature, external temperature, humidity, battery
+      datacode = h
+      scales = 0.1,0.1,0.1,0.1
+      units = C,C,%,V
+
+[[21]]
+   nodename = emonth3
+   [[[rx]]]
+      names = temperature, external temperature, humidity, battery
+      datacode = h
+      scales = 0.1,0.1,0.1,0.1
+      units = C,C,%,V
+
+[[22]]
+   nodename = emonth4
+   [[[rx]]]
+      names = temperature, external temperature, humidity, battery
+      datacode = h
+      scales = 0.1,0.1,0.1,0.1
+      units = C,C,%,V
+[[23]]
+    nodename = emonth5
+    [[[rx]]]
+       names = temperature, external temperature, humidity, battery, pulsecount
+       datacodes = h,h,h,h,L
+       scales = 0.1,0.1,0.1,0.1,1
+       units = C,C,%,V,p
+
+[[24]]
+    nodename = emonth6
+    [[[rx]]]
+       names = temperature, external temperature, humidity, battery, pulsecount
+       datacodes = h,h,h,h,L
+       scales = 0.1,0.1,0.1,0.1,1
+       units = C,C,%,V,p
+
+[[25]]
+    nodename = emonth7
+    [[[rx]]]
+       names = temperature, external temperature, humidity, battery, pulsecount
+       datacodes = h,h,h,h,L
+       scales = 0.1,0.1,0.1,0.1,1
+       units = C,C,%,V,p
+
+[[26]]
+    nodename = emonth8
+    [[[rx]]]
+       names = temperature, external temperature, humidity, battery, pulsecount
+       datacodes = h,h,h,h,L
+       scales = 0.1,0.1,0.1,0.1,1
+       units = C,C,%,V,p

--- a/src/interfacers/EmonHubVEDirectInterfacer.py
+++ b/src/interfacers/EmonHubVEDirectInterfacer.py
@@ -12,7 +12,7 @@ Monitors the serial port for data
 
 
 class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
-    
+
     (WAIT_HEADER, IN_KEY, IN_VALUE, IN_CHECKSUM) = range(4)
 
     def __init__(self, name, com_port='', com_baud=9600, toextract='' , poll_interval=30):
@@ -27,7 +27,7 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
 
         # Open serial port
         self._ser = self._open_serial_port(com_port, com_baud)
-        
+
         # Initialize RX buffer
         self._rx_buf = ''
 
@@ -42,7 +42,7 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         self.dict = {}
 	self.poll_interval = int(poll_interval)
 	self.last_read = time.time()
-        
+
         #Parser requirments
         self._extract = toextract
         #print "init system with to extract %s"%self._extract
@@ -96,7 +96,7 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
 
     def close(self):
         """Close serial port"""
-        
+
         # Close serial port
         if self._ser is not None:
             self._log.debug("Closing serial port")
@@ -145,7 +145,7 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
 
 		    clean_data = clean_data + " " + str(data[key])
 	return clean_data
-            
+
 
     def _read_serial(self):
         self._log.debug(" Starting Serial read")
@@ -159,25 +159,25 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         except Exception,e:
             self._log.error(e)
             self._rx_buf = ""
- 
+
 
     def read(self):
         """Read data from serial port and process if complete line received.
 
         Return data as a list: [NodeID, val1, val2]
-        
+
         """
 
         # Read serial RX
-	now = time.time()
-	if not (now - self.last_read) > self.poll_interval:
+        now = time.time()
+        if not (now - self.last_read) > self.poll_interval:
             #self._log.debug(" Waiting for %s seconds "%(str(now - self.last_read)))
             # Wait to read based on poll_interval
-	    return 
-	
-	# Read from serial         
-	self._read_serial()
-	# Update last read time
+	        return
+
+        # Read from serial
+        self._read_serial()
+        # Update last read time
         self.last_read = now
         # If line incomplete, exit
         if self._rx_buf == None:
@@ -188,18 +188,18 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         # Create a Payload object
         c = Cargo.new_cargo(rawdata = self._rx_buf)
         f = self.parse_package(self._rx_buf)
-	f = f.split()
+        f = f.split()
 
         # Reset buffer
         self._rx_buf = ''
 
-	if f:
+        if f:
 	        if int(self._settings['nodeoffset']):
                     c.nodeid = int(self._settings['nodeoffset'])
                     c.realdata = f[1:]
                 else:
                     self._log.error("nodeoffset needed in emonhub configuratio, make sure it exits ans is integer ")
                     pass
-                       
+
         return c
 

--- a/src/interfacers/EmonHubVEDirectInterfacer.py
+++ b/src/interfacers/EmonHubVEDirectInterfacer.py
@@ -1,0 +1,205 @@
+import time
+import serial
+import Cargo
+from pydispatch import dispatcher
+import emonhub_interfacer as ehi
+
+"""class EmonhubSerialInterfacer
+
+Monitors the serial port for data
+
+"""
+
+
+class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
+    
+    (WAIT_HEADER, IN_KEY, IN_VALUE, IN_CHECKSUM) = range(4)
+
+    def __init__(self, name, com_port='', com_baud=9600, toextract='' , poll_interval=30):
+        """Initialize interfacer
+
+        com_port (string): path to COM port
+
+        """
+
+        # Initialization
+        super(EmonHubVEDirectInterfacer, self).__init__(name)
+
+        # Open serial port
+        self._ser = self._open_serial_port(com_port, com_baud)
+        
+        # Initialize RX buffer
+        self._rx_buf = ''
+
+	#VE Direct requirements
+        self.header1 = '\r'
+        self.header2 = '\n'
+        self.delimiter = '\t'
+        self.key = ''
+        self.value = ''
+        self.bytes_sum = 0;
+        self.state = self.WAIT_HEADER
+        self.dict = {}
+	self.poll_interval = int(poll_interval)
+	self.last_read = time.time()
+        
+        #Parser requirments
+        self._extract = toextract
+        #print "init system with to extract %s"%self._extract
+
+
+    def input(self, byte):
+        """
+	Parse serial byte code from VE.Direct
+	"""
+        if self.state == self.WAIT_HEADER:
+            self.bytes_sum += ord(byte)
+            if byte == self.header1:
+                self.state = self.WAIT_HEADER
+            elif byte == self.header2:
+                self.state = self.IN_KEY
+
+            return None
+        elif self.state == self.IN_KEY:
+            self.bytes_sum += ord(byte)
+            if byte == self.delimiter:
+                if (self.key == 'Checksum'):
+                    self.state = self.IN_CHECKSUM
+                else:
+                    self.state = self.IN_VALUE
+            else:
+                self.key += byte
+            return None
+        elif self.state == self.IN_VALUE:
+            self.bytes_sum += ord(byte)
+            if byte == self.header1:
+                self.state = self.WAIT_HEADER
+                self.dict[self.key] = self.value;
+                self.key = '';
+                self.value = '';
+            else:
+                self.value += byte
+            return None
+        elif self.state == self.IN_CHECKSUM:
+            self.bytes_sum += ord(byte)
+            self.key = ''
+            self.value = ''
+            self.state = self.WAIT_HEADER
+            if (self.bytes_sum % 256 == 0):
+                self.bytes_sum = 0
+                return self.dict
+            else:
+                self.bytes_sum = 0
+
+        else:
+            raise AssertionError()
+
+    def close(self):
+        """Close serial port"""
+        
+        # Close serial port
+        if self._ser is not None:
+            self._log.debug("Closing serial port")
+            self._ser.close()
+
+    def _open_serial_port(self, com_port, com_baud):
+        """Open serial port
+
+        com_port (string): path to COM port
+
+        """
+
+        #if not int(com_baud) in [75, 110, 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200]:
+        #    self._log.debug("Invalid 'com_baud': " + str(com_baud) + " | Default of 9600 used")
+        #    com_baud = 9600
+
+        try:
+            s = serial.Serial(com_port, com_baud, timeout=10)
+            self._log.debug("Opening serial port: " + str(com_port) + " @ "+ str(com_baud) + " bits/s")
+        except serial.SerialException as e:
+            self._log.error(e)
+            raise EmonHubInterfacerInitError('Could not open COM port %s' %
+                                           com_port)
+        else:
+            return s
+
+    def parse_package(self,data):
+        """
+        Convert package from vedirect dictionary format to emonhub expected format
+
+        """
+        clean_data = "%s"%self._settings['nodeoffset']
+        for key in self._extract:
+            if data.has_key(key):
+                    #Emonhub doesn't like strings so we convert them to ints
+                    tempval = 0
+                    try:
+                        tempval = float(data[key])
+                    except Exception,e:
+			tempval = data[key]
+                    if not isinstance(tempval,float):
+                       if data[key] == "OFF":
+                          data[key] = 0
+                       else:
+                          data[key] = 1
+
+		    clean_data = clean_data + " " + str(data[key])
+	return clean_data
+            
+
+    def _read_serial(self):
+        self._log.debug(" Starting Serial read")
+        try:
+            while self._rx_buf == '':
+		    byte = self._ser.read(1)
+		    packet = self.input(byte)
+		    if packet != None:
+			self._rx_buf = packet
+
+        except Exception,e:
+            self._log.error(e)
+            self._rx_buf = ""
+ 
+
+    def read(self):
+        """Read data from serial port and process if complete line received.
+
+        Return data as a list: [NodeID, val1, val2]
+        
+        """
+
+        # Read serial RX
+	now = time.time()
+	if not (now - self.last_read) > self.poll_interval:
+            #self._log.debug(" Waiting for %s seconds "%(str(now - self.last_read)))
+            # Wait to read based on poll_interval
+	    return 
+	
+	# Read from serial         
+	self._read_serial()
+	# Update last read time
+        self.last_read = now
+        # If line incomplete, exit
+        if self._rx_buf == None:
+            return
+
+        #Sample data looks like {'FW': '0307', 'SOC': '1000', 'Relay': 'OFF', 'PID': '0x203', 'H10': '6', 'BMV': '700', 'TTG': '-1', 'H12': '0', 'H18': '0', 'I': '0', 'H11': '0', 'Alarm': 'OFF', 'CE': '0', 'H17': '9', 'P': '0', 'AR': '0', 'V': '26719', 'H8': '29011', 'H9': '0', 'H2': '0', 'H3': '0', 'H1': '-1633', 'H6': '-5775', 'H7': '17453', 'H4': '0', 'H5': '0'}
+
+        # Create a Payload object
+        c = Cargo.new_cargo(rawdata = self._rx_buf)
+        f = self.parse_package(self._rx_buf)
+	f = f.split()
+
+        # Reset buffer
+        self._rx_buf = ''
+
+	if f:
+	        if int(self._settings['nodeoffset']):
+                    c.nodeid = int(self._settings['nodeoffset'])
+                    c.realdata = f[1:]
+                else:
+                    self._log.error("nodeoffset needed in emonhub configuratio, make sure it exits ans is integer ")
+                    pass
+                       
+        return c
+


### PR DESCRIPTION
Sending in PR for Victron product Integration.
**Notes**
- VE Direct is a binary protocol used by most Victron Energy products to communicate.
- Most VE Direct products connect through a  isolated FTDI - USB cable.

**Testing**
- This module has been tested on the BMV 700 which is a low cost battery monitoring unit.

**Configuration**
- Sample configuration has been added to the emonhub.conf file with comments
