### PR TITLE
Don't chown if no logfile defined!

### DIFF
--- a/service/emonhub
+++ b/service/emonhub
@@ -32,7 +32,7 @@ SYSCONF_PATH=/etc/default/
 [ ! -f $EMONHUB_PATH$NAME.py ] && echo "Fatal: cannot find $EMONHUB_PATH$NAME.py" && exit 1
 [ ! -z $EMONHUB_LOG ] || [ ! -f $EMONHUB_LOG ] && sudo mkdir -p "$(dirname "$EMONHUB_LOG")" && sudo touch "$EMONHUB_LOG" && sudo chown -R $DAEMONUSER "$(dirname "$EMONHUB_LOG")"
 
-sudo chown -R $DAEMONUSER "$(dirname "$EMONHUB_LOG")"
+[ ! -z $EMONHUB_LOG ] && sudo chown -R $DAEMONUSER "$(dirname "$EMONHUB_LOG")"
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin


### PR DESCRIPTION
This is a critical fix for PR #12 which causes the entire filesystem to be owned by emonhub if no log file is defined.  Sorry!