### PR TITLE
3phase: fixed missing pulse configuration and add more nodes

### DIFF
--- a/conf/emonpi.default.emonhub.conf
+++ b/conf/emonpi.default.emonhub.conf
@@ -133,6 +133,30 @@ loglevel = DEBUG
        datacode = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p
+       
+[[12]]
+    nodename = 3phase2
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[13]]
+    nodename = 3phase3
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[14]]
+    nodename = 3phase4
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
 
 [[19]]
    nodename = emonth1

--- a/conf/nodes/11
+++ b/conf/nodes/11
@@ -1,7 +1,7 @@
 [[11]]
     nodename = 3phase
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6
-       datacode = h
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1
-       units =W,W,W,W,V,C,C,C,C,C,C
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p

--- a/conf/nodes/12
+++ b/conf/nodes/12
@@ -1,0 +1,7 @@
+[[12]]
+    nodename = 3phase2
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p

--- a/conf/nodes/13
+++ b/conf/nodes/13
@@ -1,0 +1,7 @@
+[[13]]
+    nodename = 3phase3
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p

--- a/conf/nodes/14
+++ b/conf/nodes/14
@@ -1,0 +1,7 @@
+[[14]]
+    nodename = 3phase4
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p


### PR DESCRIPTION
Hi, 
the pulse configuration was missing here: emonhub/conf/nodes/11.
And I added more preconfigured nodeID's for 3phase. Probably nothing everyone needs ;) but the first issue should be fixed.
