### PR TITLE
fixed missing "s" in datacodes

### DIFF
--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -139,6 +139,30 @@ loglevel = DEBUG #(default:WARNING)
        datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p
+       
+ [[12]]
+    nodename = 3phase2
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[13]]
+    nodename = 3phase3
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
+
+[[14]]
+    nodename = 3phase4
+    [[[rx]]]
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
 
 [[19]]
    nodename = emonth1

--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -135,10 +135,10 @@ loglevel = DEBUG #(default:WARNING)
 [[11]]
     nodename = 3phase
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
 
 [[19]]
    nodename = emonth1

--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -136,7 +136,7 @@ loglevel = DEBUG #(default:WARNING)
     nodename = 3phase
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p
 

--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -135,10 +135,10 @@ loglevel = DEBUG #(default:WARNING)
 [[11]]
     nodename = 3phase
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
 
 [[19]]
    nodename = emonth1

--- a/conf/emonpi.default.emonhub.conf
+++ b/conf/emonpi.default.emonhub.conf
@@ -129,34 +129,34 @@ loglevel = DEBUG
 [[11]]
     nodename = 3phase
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
        
 [[12]]
     nodename = 3phase2
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
 
 [[13]]
     nodename = 3phase3
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
 
 [[14]]
     nodename = 3phase4
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,pp
+       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,V,C,C,C,C,C,C,p
 
 [[19]]
    nodename = emonth1

--- a/conf/emonpi.default.emonhub.conf
+++ b/conf/emonpi.default.emonhub.conf
@@ -129,34 +129,34 @@ loglevel = DEBUG
 [[11]]
     nodename = 3phase
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
        
 [[12]]
     nodename = 3phase2
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
 
 [[13]]
     nodename = 3phase3
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,p
 
 [[14]]
     nodename = 3phase4
     [[[rx]]]
-       names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       names = powerL1, powerL2, powerL3, power4, currentL1, currentL2, currentL3, current4, powerFactorL1, powerFactorL2, powerFactorL3, powerFactor4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6,pulse
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
+       units =W,W,W,W,A,A,A,A,pf,pf,pf,pf,V,C,C,C,C,C,C,pp
 
 [[19]]
    nodename = emonth1

--- a/conf/emonpi.default.emonhub.conf
+++ b/conf/emonpi.default.emonhub.conf
@@ -130,7 +130,7 @@ loglevel = DEBUG
     nodename = 3phase
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p
        

--- a/conf/nodes/11
+++ b/conf/nodes/11
@@ -2,6 +2,6 @@
     nodename = 3phase
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p

--- a/conf/nodes/12
+++ b/conf/nodes/12
@@ -2,6 +2,6 @@
     nodename = 3phase2
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p

--- a/conf/nodes/13
+++ b/conf/nodes/13
@@ -2,6 +2,6 @@
     nodename = 3phase3
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       units = W,W,W,W,V,C,C,C,C,C,C,p

--- a/conf/nodes/14
+++ b/conf/nodes/14
@@ -2,6 +2,6 @@
     nodename = 3phase4
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       units = W,W,W,W,V,C,C,C,C,C,C,p


### PR DESCRIPTION
Hi Glyn,
thanks for merging the last pull request so fast! :)
Found another importing issue: With adding the "L" data code here: https://github.com/openenergymonitor/emonhub/commit/e49fb781492155113cda20c783dee8b0b5eccc99 "datacode" has to be changed to "datacodes".

This one is important because otherwise emonhub stops with: `MainThread RFM2Pi thread is dead`
I did copy&paste the error with my last pull request, sorry! That's why I also updated: conf/nodes/11 till conf/nodes/14.
Best, Elias