### PR TITLE
Fix whitespace with autopep8 . --recursive --select=E101,E121 --in-place

### DIFF
--- a/examples/mqtt_reader.py
+++ b/examples/mqtt_reader.py
@@ -6,7 +6,7 @@ def on_connect(client, userdata, rc):
     client.subscribe("emonhub/#")
 
 def on_message(client, userdata, msg):
-	print(msg.topic+" "+str(msg.payload))
+    print(msg.topic+" "+str(msg.payload))
 
 client = mqtt.Client()
 client.on_connect = on_connect

--- a/src/interfacers/EmonFroniusModbusTcpInterfacer.py
+++ b/src/interfacers/EmonFroniusModbusTcpInterfacer.py
@@ -23,11 +23,11 @@ class EmonFroniusModbusTcpInterfacer(ehi.EmonModbusTcpInterfacer):
 
     # Connection opened by parent class INIT
     # Retrieve fronius specific inverter info if connection successfull if connection successfull
-	self._log.debug("Fronius args: " + str(modbus_IP) + " - " + str(modbus_port) )
-	self._log.debug("EmonFroniusModbusTcpInterfacer: Init")
-	if self._modcon :
+        self._log.debug("Fronius args: " + str(modbus_IP) + " - " + str(modbus_port) )
+        self._log.debug("EmonFroniusModbusTcpInterfacer: Init")
+        if self._modcon :
             # Display device firmware version and current settings
-	    self.info =["",""]
+            self.info =["",""]
             #self._log.info("Modtcp Connected")
             r2= self._con.read_holding_registers(40005-1,4,unit=1)
             r3= self._con.read_holding_registers(40021-1,4,unit=1)

--- a/src/interfacers/EmonHubBMWInterfacer.py
+++ b/src/interfacers/EmonHubBMWInterfacer.py
@@ -126,9 +126,9 @@ class EmonHubBMWInterfacer(EmonHubInterfacer):
         return
 
     def saveCredentials(self):
-    	"""
-    	Save current state to the JSON file.
-    	"""
+        """
+        Save current state to the JSON file.
+        """
         credentials = {
             #"auth_basic": self.auth_basic,
             "access_token": self._AccessToken,

--- a/src/interfacers/EmonHubVEDirectInterfacer.py
+++ b/src/interfacers/EmonHubVEDirectInterfacer.py
@@ -31,7 +31,7 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         # Initialize RX buffer
         self._rx_buf = ''
 
-	#VE Direct requirements
+        #VE Direct requirements
         self.header1 = '\r'
         self.header2 = '\n'
         self.delimiter = '\t'
@@ -40,8 +40,8 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         self.bytes_sum = 0;
         self.state = self.WAIT_HEADER
         self.dict = {}
-	self.poll_interval = int(poll_interval)
-	self.last_read = time.time()
+        self.poll_interval = int(poll_interval)
+        self.last_read = time.time()
 
         #Parser requirments
         self._extract = toextract
@@ -50,8 +50,8 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
 
     def input(self, byte):
         """
-	Parse serial byte code from VE.Direct
-	"""
+        Parse serial byte code from VE.Direct
+        """
         if self.state == self.WAIT_HEADER:
             self.bytes_sum += ord(byte)
             if byte == self.header1:
@@ -132,29 +132,29 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         for key in self._extract:
             if data.has_key(key):
                     #Emonhub doesn't like strings so we convert them to ints
-                    tempval = 0
-                    try:
-                        tempval = float(data[key])
-                    except Exception,e:
-			tempval = data[key]
-                    if not isinstance(tempval,float):
-                       if data[key] == "OFF":
-                          data[key] = 0
-                       else:
-                          data[key] = 1
+                tempval = 0
+                try:
+                    tempval = float(data[key])
+                except Exception,e:
+                    tempval = data[key]
+                if not isinstance(tempval,float):
+                    if data[key] == "OFF":
+                        data[key] = 0
+                    else:
+                        data[key] = 1
 
-		    clean_data = clean_data + " " + str(data[key])
-	return clean_data
+                clean_data = clean_data + " " + str(data[key])
+        return clean_data
 
 
     def _read_serial(self):
         self._log.debug(" Starting Serial read")
         try:
             while self._rx_buf == '':
-		    byte = self._ser.read(1)
-		    packet = self.input(byte)
-		    if packet != None:
-			self._rx_buf = packet
+                byte = self._ser.read(1)
+                packet = self.input(byte)
+                if packet != None:
+                    self._rx_buf = packet
 
         except Exception,e:
             self._log.error(e)
@@ -173,7 +173,7 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         if not (now - self.last_read) > self.poll_interval:
             #self._log.debug(" Waiting for %s seconds "%(str(now - self.last_read)))
             # Wait to read based on poll_interval
-	        return
+            return
 
         # Read from serial
         self._read_serial()
@@ -194,12 +194,11 @@ class EmonHubVEDirectInterfacer(ehi.EmonHubInterfacer):
         self._rx_buf = ''
 
         if f:
-	        if int(self._settings['nodeoffset']):
-                    c.nodeid = int(self._settings['nodeoffset'])
-                    c.realdata = f[1:]
-                else:
-                    self._log.error("nodeoffset needed in emonhub configuratio, make sure it exits ans is integer ")
-                    pass
+            if int(self._settings['nodeoffset']):
+                c.nodeid = int(self._settings['nodeoffset'])
+                c.realdata = f[1:]
+            else:
+                self._log.error("nodeoffset needed in emonhub configuratio, make sure it exits ans is integer ")
+                pass
 
         return c
-

--- a/src/interfacers/EmonModbusTcpInterfacer.py
+++ b/src/interfacers/EmonModbusTcpInterfacer.py
@@ -25,12 +25,12 @@ class EmonModbusTcpInterfacer(ehi.EmonHubInterfacer):
         super(EmonModbusTcpInterfacer, self).__init__(name)
 
     # open connection
-	self._log.debug("EmonModbusTcpInterfacer args: " + str(modbus_IP) + " - " + str(modbus_port) )
-	self._con = self._open_modTCP(modbus_IP,modbus_port)
-	if self._modcon :
+        self._log.debug("EmonModbusTcpInterfacer args: " + str(modbus_IP) + " - " + str(modbus_port) )
+        self._con = self._open_modTCP(modbus_IP,modbus_port)
+        if self._modcon :
             self._log.info("Modbustcp client Connected")
-	else:
-	    self._log.info("Connection to ModbusTCP client failed. Will try again")
+        else:
+            self._log.info("Connection to ModbusTCP client failed. Will try again")
 
 
     def set(self, **kwargs):
@@ -41,7 +41,7 @@ class EmonModbusTcpInterfacer(ehi.EmonHubInterfacer):
             self._log.debug("Setting " + self.name + " %s: %s" % (key, setting) )
 
     def close(self):
-                    
+
         # Close TCP connection
         if self._con is not None:
             self._log.debug("Closing tcp port")
@@ -52,16 +52,16 @@ class EmonModbusTcpInterfacer(ehi.EmonHubInterfacer):
 
         try:
             c = ModbusClient(modbus_IP,modbus_port)
-	    if c.connect():
+            if c.connect():
                 self._log.info("Opening modbusTCP connection: " + str(modbus_port) + " @ " +str(modbus_IP))
-		self._modcon = True
-	    else:
-		self._log.debug("Connection failed")
-		self._modcon = False
+                self._modcon = True
+            else:
+                self._log.debug("Connection failed")
+                self._modcon = False
         except Exception as e:
             self._log.error("modbusTCP connection failed" + str(e))
             #raise EmonHubInterfacerInitError('Could not open connection to host %s' %modbus_IP)
-	    pass
+            pass
         else:
             return c
 
@@ -69,18 +69,18 @@ class EmonModbusTcpInterfacer(ehi.EmonHubInterfacer):
     def read(self):
         """ Read registers from client"""
 
-	time.sleep(float(self._settings["interval"]))
-	f = []
+        time.sleep(float(self._settings["interval"]))
+        f = []
         c = Cargo.new_cargo(rawdata="")
         if not self._modcon :
-	   self._con.close()
-	   self._log.info("Not connected, retrying connect" + str(self.init_settings))
-	   self._con = self._open_modTCP(self.init_settings["modbus_IP"],self.init_settings["modbus_port"])
+            self._con.close()
+            self._log.info("Not connected, retrying connect" + str(self.init_settings))
+            self._con = self._open_modTCP(self.init_settings["modbus_IP"],self.init_settings["modbus_port"])
 
-	if self._modcon :
+        if self._modcon :
             #self._log.info(" names " + str(self._settings["rName"]))
-	    rNameList = self._settings["rName"]
-	    #self._log.info("rNames type: " + str(type(rNameList)))
+            rNameList = self._settings["rName"]
+            #self._log.info("rNames type: " + str(type(rNameList)))
             registerList = self._settings["register"]
             nRegList = self._settings["nReg"]
             rTypeList = self._settings["rType"]
@@ -89,19 +89,19 @@ class EmonModbusTcpInterfacer(ehi.EmonHubInterfacer):
                 register = int(registerList[idx])
                 qty = int(nRegList[idx])
                 rType = rTypeList[idx]
-	        self._log.debug("register # : " + str(register))
+                self._log.debug("register # : " + str(register))
 
                 try:
-		    self.rVal = self._con.read_holding_registers(register-1,qty,unit=1)
+                    self.rVal = self._con.read_holding_registers(register-1,qty,unit=1)
                     assert(self.rVal.function_code < 0x80)
-		except Exception as e:
-		    self._log.error("Connection failed on read of register: " +str(register) + " : " + str(e))
-		    self._modcon = False
-		else:
-	            #self._log.debug("register value:" + str(self.rVal.registers)+" type= " + str(type(self.rVal.registers)))
-	            #f = f + self.rVal.registers
+                except Exception as e:
+                    self._log.error("Connection failed on read of register: " +str(register) + " : " + str(e))
+                    self._modcon = False
+                else:
+                    #self._log.debug("register value:" + str(self.rVal.registers)+" type= " + str(type(self.rVal.registers)))
+                    #f = f + self.rVal.registers
                     decoder = BinaryPayloadDecoder.fromRegisters(self.rVal.registers, endian=Endian.Big)
-		    self._log.debug("register type: " + str(rType))
+                    self._log.debug("register type: " + str(rType))
 
                     if rType == "uint16":
                         rValD = decoder.decode_16bit_uint()
@@ -125,17 +125,17 @@ class EmonModbusTcpInterfacer(ehi.EmonHubInterfacer):
                         rValD = decoder.decode_32bit_float()*10
                         t = emonhub_coder.encode('f',rValD)
                         f = f + list(t)
-		    else:
-			self._log.error("Register type not found: "+ str(rType) + " Register:" + str(register))
+                    else:
+                        self._log.error("Register type not found: "+ str(rType) + " Register:" + str(register))
                     self._log.debug("Encoded value: " + str(t))
-           
-	    self._log.debug("reporting data: " + str(f)) 
+
+            self._log.debug("reporting data: " + str(f))
             if int(self._settings['nodeId']):
                 c.nodeid = int(self._settings['nodeId'])
                 c.realdata = f
             else:
                 c.nodeid = int(12)
                 c.realdata = f
-	    self._log.debug("Return from read data: " + str(c.realdata))	
-	 
+            self._log.debug("Return from read data: " + str(c.realdata))
+
         return c


### PR DESCRIPTION
I've run autopep8 ( https://pypi.python.org/pypi/autopep8 ) - a lot of the changes are tab to space expansion (most files used spaces already, but a few had some tabs thrown in - this is a syntax error in python3 - https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces )

autopep8 . --recursive --select=E101,E121 --in-place

autopep8 also has many other options, and the defaults would make many more changes to the code base (the majority of them good IMO, at the very least it'll make the code a lot more consistent - there are a lot of inconsistencies both between and within files currently), but I haven't run it, as this is more a matter of taste!

I have a local version of emonhub running under python3 which I'd be happy to commit if desired (python2 will be unsupported from 2020) - the changes are pretty trivial, I'll submit another pull request if you like...

Cheers,

Tim.