### PR TITLE
Normalise file paths

### DIFF
--- a/src/emonhub.py
+++ b/src/emonhub.py
@@ -25,7 +25,7 @@ from interfacers import *
 
 # this namespace and path
 namespace = sys.modules[__name__]
-path = os.path.dirname(__file__)
+path = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
 
 # scan interfacers directory and import all interfacers
 for f in glob.glob(path+"/interfacers/*.py"):


### PR DESCRIPTION
e.g. to correctly dereference symbolic links when using venv.