### PR TITLE
Use named fields when sending data to Emoncms

### DIFF
--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -139,12 +139,21 @@ class EmonHubInterfacer(threading.Thread):
         else:
             node_name = cargo.nodeid
 
+        datalist = []
+        if len(cargo.names) == len(cargo.realdata):
+            for name, data in zip(cargo.names, cargo.realdata):
+                datalist.append({name: data})
+        else:
+            datalist = cargo.realdata
+            if len(cargo.names) > 0:
+                self._log.warning("cargo.names and cargo.realdata have different lengths - " + str(len(cargo.names)) + " vs " + str(len(cargo.realdata)))
+
         # Create a frame of data in "emonCMS format"
         f = []
         try:
             f.append(cargo.timestamp)
             f.append(node_name)
-            for i in cargo.realdata:
+            for i in datalist:
                 f.append(i)
             if cargo.rssi:
                 f.append(cargo.rssi)

--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -134,11 +134,16 @@ class EmonHubInterfacer(threading.Thread):
 
         """
 
+        if cargo.nodename:
+            node_name = cargo.nodename
+        else:
+            node_name = cargo.nodeid
+
         # Create a frame of data in "emonCMS format"
         f = []
         try:
             f.append(cargo.timestamp)
-            f.append(cargo.nodeid)
+            f.append(node_name)
             for i in cargo.realdata:
                 f.append(i)
             if cargo.rssi:


### PR DESCRIPTION
This patch changes the data sent to Emoncms in two different ways:
 - If nodename is given in the node configuration, that is used instead of the node ID
 - If the names field is given in the node configuration, that is used instead of numeric indeces

The end result is an URL like this:
https://emoncms.org/input/bulk.json?apikey=xxxx&data=[[1523217030.786124,"Sensornode",{"temp":23.47},{"humidity":23.62},{"battery":29}]]&sentat=1523217045
instead of
https://emoncms.org/input/bulk.json?apikey=xxxx&data=[[1523217030.786124,42,23.47,23.62,29]]&sentat=1523217045

I guess this will break stuff for some people, so I don't really suggest this to be merged as-is. Nevertheless, I think it's useful in many cases (it was for me), hence the pull request. Perhaps someone more familiar with the system and the use-cases can get this in in a way that won't break existing setups?