### PR TITLE
Correction to http send interval setting

### DIFF
--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -74,7 +74,7 @@ loglevel = DEBUG #(default:WARNING)
         apikey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
         senddata = 0                    # Enable sending data to Emoncms.org
         sendstatus = 1                  # Enable sending WAN IP to Emoncms.org MyIP > https://emoncms.org/myip/list
-        sendinterval= 30                # Bulk send interval to Emoncms.org in seconds
+        interval = 30                   # Bulk send interval to Emoncms.org in seconds
 
 #######################################################################
 #######################          Nodes          #######################


### PR DESCRIPTION
Changed fron "sendinterval" to "interval" in this commit https://github.com/openenergymonitor/emonhub/commit/65278b2f0781455193f0df5510adc6179e9ca724#diff-fe9e89ada790e8b585d207fdb5d331ab 
See https://community.openenergymonitor.org/t/cannot-change-post-interval-to-external-emoncms-cms/7524/7?u=pb66