### PR TITLE
Missing import module causing compile error

### DIFF
--- a/src/interfacers/EmonHubSMASolarInterfacer.py
+++ b/src/interfacers/EmonHubSMASolarInterfacer.py
@@ -13,7 +13,7 @@ except ImportError:
 import time
 import sys
 import traceback
-
+import re
 import Cargo
 
 from time import sleep


### PR DESCRIPTION
Resolves error

global name ‘re’ is not defined
