### PR TITLE
Fix scale and datacode errors

### DIFF
--- a/conf/emonpi.default.emonhub.conf
+++ b/conf/emonpi.default.emonhub.conf
@@ -92,7 +92,7 @@ loglevel = DEBUG
        names = power1, power2, power3, power4, vrms
        datacode = h
        scales = 1,1,1,1,0.01
-       units =W,W,W,W,V
+       units = W,W,W,W,V
 
 [[7]]
    nodename = emontx4
@@ -100,7 +100,7 @@ loglevel = DEBUG
       names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
       scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-      units =W,W,W,W,V,C,C,C,C,C,C,p
+      units = W,W,W,W,V,C,C,C,C,C,C,p
 
 [[8]]
     nodename = emontx3
@@ -108,55 +108,55 @@ loglevel = DEBUG
        names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
        datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       units = W,W,W,W,V,C,C,C,C,C,C,p
 
 [[9]]
    nodename = emontx2
    [[[rx]]]
       names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-      datacode = h
+      datacodes = h,h,h,h,h,h,h,h,h,h,h,L
       scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-      units =W,W,W,W,V,C,C,C,C,C,C,p
+      units = W,W,W,W,V,C,C,C,C,C,C,p
 
 [[10]]
     nodename = emontx1
     [[[rx]]]
        names = power1, power2, power3, power4, vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h
-       scales = 1,1,1,1,0.01,0.1,0.1, 0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,1
+       units = W,W,W,W,V,C,C,C,C,C,C,p
 
 [[11]]
     nodename = 3phase
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
        datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,1
+       units = W,W,W,W,V,C,C,C,C,C,C,p
        
 [[12]]
     nodename = 3phase2
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
        datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,1
+       units = W,W,W,W,V,C,C,C,C,C,C,p
 
 [[13]]
     nodename = 3phase3
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
        datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,1
+       units = W,W,W,W,V,C,C,C,C,C,C,p
 
 [[14]]
     nodename = 3phase4
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
        datacodes = h,h,h,h,h,h,h,h,h,h,h,L
-       scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
-       units =W,W,W,W,V,C,C,C,C,C,C,p
+       scales = 1,1,1,1,0.01,0.01,0.01,0.01,0.01,0.01,0.01,1
+       units = W,W,W,W,V,C,C,C,C,C,C,p
 
 [[19]]
    nodename = emonth1


### PR DESCRIPTION
Amended as per Robert Wall's advice:

The temperatures in nodeIDs 11-14 were wrong by a factor of 10 - the 3-phase sketch sends hundredths of a degree, not tenths.

NodeIDs 9 & 10 will not have worked for anyone using the standard default sketch because the final value (pulse count) sent is an unsigned long (L), as in nodeIDs 7 & 8.