### PR TITLE
Fix #115

### DIFF
--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -252,9 +252,9 @@ class EmonHubInterfacer(threading.Thread):
             else:
                 reply = requests.get(post_url)
             reply.raise_for_status()  # Raise an exception if status code isn't 200
+            return reply.text
         except requests.exceptions.RequestException as ex:
             self._log.warning(self.name + " couldn't send to server: " + str(ex))
-        return reply.text
 
     def _process_rx(self, cargo):
         """Process a frame of data

--- a/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
+++ b/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
@@ -70,10 +70,10 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
 
         reply = self._send_post(post_url, {'data': data_string, 'sentat': str(sentat)})
         if reply == 'ok':
-            self._log.debug("acknowledged receipt with '" + reply + "' from " + self._settings['url'])
+            self._log.debug("acknowledged receipt with '%s' from %s", reply, self._settings['url'])
             return True
         else:
-            self._log.warning("send failure: wanted 'ok' but got '" + reply + "'")
+            self._log.warning("send failure: wanted 'ok' but got '%s'", reply)
             return False
 
     def sendstatus(self):


### PR DESCRIPTION
If an exception is raised, the return value is undefined, so another (uncaught) exception is raised. Fix that.

Also, the return value can be None if that happens, so make sure to format the reply in the log message if necessary.