### PR TITLE
Set timeouts on requests transactions.

### DIFF
--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -248,9 +248,9 @@ class EmonHubInterfacer(threading.Thread):
 
         try:
             if post_body:
-                reply = requests.post(post_url, post_body)
+                reply = requests.post(post_url, post_body, timeout=60)
             else:
-                reply = requests.get(post_url)
+                reply = requests.get(post_url, timeout=60)
             reply.raise_for_status()  # Raise an exception if status code isn't 200
             return reply.text
         except requests.exceptions.RequestException as ex:

--- a/src/interfacers/EmonHubBMWInterfacer.py
+++ b/src/interfacers/EmonHubBMWInterfacer.py
@@ -168,9 +168,9 @@ class EmonHubBMWInterfacer(EmonHubInterfacer):
         #self._log.debug("headers=" + str(headers))
 
         if post_data is None:
-            r = requests.get(self.ROOT_URL + path, headers=headers)
+            r = requests.get(self.ROOT_URL + path, headers=headers, timeout=60)
         else:
-            r = requests.post(self.ROOT_URL + path, headers=headers, data=post_data)
+            r = requests.post(self.ROOT_URL + path, headers=headers, data=post_data, timeout=60)
 
         #Raise exception if problem with request
         r.raise_for_status()

--- a/src/interfacers/EmonHubPacketGenInterfacer.py
+++ b/src/interfacers/EmonHubPacketGenInterfacer.py
@@ -41,7 +41,7 @@ class EmonHubPacketGenInterfacer(EmonHubInterfacer):
         self._log.info("requesting packet: " + req + "E-M-O-N-C-M-S-A-P-I-K-E-Y")
 
         try:
-            packet = requests.get(req + self._settings['apikey']).json()
+            packet = requests.get(req + self._settings['apikey'], timeout=60).json()
         except (ValueError, requests.exceptions.RequestException) as ex:
             self._log.warning("no packet returned: " + str(ex))
             return
@@ -96,7 +96,7 @@ class EmonHubPacketGenInterfacer(EmonHubInterfacer):
             try:
                 z = requests.get(self._settings['url'] +
                                  "/emoncms/packetgen/getinterval.json?apikey="
-                                 + self._settings['apikey']).text
+                                 + self._settings['apikey'], timeout=60).text
                 i = int(z[1:-1])
             except:
                 self._log.info("request interval not returned")

--- a/src/interfacers/EmonHubTeslaPowerWallInterfacer.py
+++ b/src/interfacers/EmonHubTeslaPowerWallInterfacer.py
@@ -35,7 +35,7 @@ class EmonHubTeslaPowerWallInterfacer(EmonHubInterfacer):
             if self._settings['url']:
                 # HTTP Request
                 try:
-                    reply = requests.get(self._settings['url'], timeout=int(self._settings['readinterval']), verify=False)
+                    reply = requests.get(self._settings['url'], timeout=int(self._settings['readinterval']), verify=False, timeout=60)
                     reply.raise_for_status()  # Raise an exception if status code isn't 200
                 except requests.exceptions.RequestException as ex:
                     self._log.warning("%s couldn't send to server: %s", self.name, ex)


### PR DESCRIPTION
Requests will wait forever for a response once the server has opened the
connection. This might cause hard to detect bugs. Set a ridiculously
long timeout. From the docs:

timeout is not a time limit on the entire response download; rather, an
exception is raised if the server has not issued a response for timeout
seconds (more precisely, if no bytes have been received on the
underlying socket for timeout seconds). If no timeout is specified
explicitly, requests do not time out.