### PR TITLE
Include serial number in emoncms HTTP post 

### DIFF
--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -161,7 +161,7 @@ class EmonHubInterfacer(threading.Thread):
         f = []
         try:
             f.append(cargo.timestamp)
-            f.append(cargo.nodeid)
+            f.append(str(self._settings['serial_num'])+str(cargo.nodeid))
             # FIXME replace with f.extend(cargo.realdata)
             for i in cargo.realdata:
                 f.append(i)

--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -442,7 +442,7 @@ class EmonHubInterfacer(threading.Thread):
         nodename = False
         if node in ehc.nodelist and 'nodename' in ehc.nodelist[node]:
             nodename = ehc.nodelist[node]['nodename']
-        rxc.nodename = self._settings['serial_num']+nodename
+        rxc.nodename = str(self._settings['serial_num'])+str(nodename)
 
         if not rxc:
             return False

--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -83,6 +83,30 @@ class EmonHubInterfacer(threading.Thread):
 
         # create a stop
         self.stop = False
+        
+        # Read RaspberryPi serial number if applicable     
+        pi_serial = False
+        try:
+          f = open('/proc/cpuinfo','r')
+          for line in f:
+            if line[0:6]=='Serial':
+              length=len(line)
+              pi_serial = line[11:length-1]
+          f.close()
+        except:
+          pi_serial = False
+
+        if pi_serial:
+          pi_serial_short = ""
+          zero_flag = 1
+          for i in range(0,len(pi_serial)):
+            if pi_serial[i]!='0':
+              zero_flag = 0
+            if not zero_flag:
+              pi_serial_short += pi_serial[i]
+          self._settings['serial_num'] = pi_serial_short.upper()+"_"
+        else:
+          self._settings['serial_num'] = ""
 
     @log_exceptions_from_class_method
     def run(self):
@@ -418,7 +442,7 @@ class EmonHubInterfacer(threading.Thread):
         nodename = False
         if node in ehc.nodelist and 'nodename' in ehc.nodelist[node]:
             nodename = ehc.nodelist[node]['nodename']
-        rxc.nodename = nodename
+        rxc.nodename = self._settings['serial_num']+nodename
 
         if not rxc:
             return False


### PR DESCRIPTION
This branch is for testing including the RasPi serial number in the Emoncms nodename

```
 cd /opt/openenergymonitor/emonhub
git checkout include_serial_number
git pull
sudo service emonhub restart
```

![1a7632bd-0c94-4ed1-9d02-83237bca25d8](https://user-images.githubusercontent.com/758844/91301506-f3d5a200-e79c-11ea-92f4-f1529e21bb16.jpeg)
