### PR TITLE
Encode the graphite message to bytes before sending it

### DIFF
--- a/src/interfacers/EmonHubGraphiteInterfacer.py
+++ b/src/interfacers/EmonHubGraphiteInterfacer.py
@@ -98,7 +98,7 @@ class EmonHubGraphiteInterfacer(EmonHubInterfacer):
         try:
             sock = socket.socket()
             sock.connect((host, port))
-            sock.sendall(message)
+            sock.sendall(message.encode())
             sock.close()
         except socket.error as e:
             self._log.error(e)


### PR DESCRIPTION
This caused an issue trying to submit these when running in Python3. This patch has sorted things out in my usage