### PR TITLE
Check for data message in message String

### DIFF
--- a/src/interfacers/EmonHubTx3eInterfacer.py
+++ b/src/interfacers/EmonHubTx3eInterfacer.py
@@ -55,7 +55,7 @@ class EmonHubTx3eInterfacer(ehi.EmonHubSerialInterfacer):
 
         #Check message string for data else publish startup messages from EmonTX
         if f.find("MSG:",0,4) == -1:
-            self._log.debug("START MESSAGE: %s", f)
+            self._log.info("START MESSAGE: %s", f)
             self._rx_buf = ''
             return False
 

--- a/src/interfacers/EmonHubTx3eInterfacer.py
+++ b/src/interfacers/EmonHubTx3eInterfacer.py
@@ -49,14 +49,14 @@ class EmonHubTx3eInterfacer(ehi.EmonHubSerialInterfacer):
         if '\r\n' not in self._rx_buf:
             # If string longer than 3 print message
             if len(self._rx_buf) > 3:
-                self._log.debug("START MESSAGE: %s", self._rx_buf.rstrip())
+                self._log.info("START MESSAGE: %s", self._rx_buf.rstrip())
 
             self._rx_buf = ''
             return False
 
         #Check for MSG data string. If not found...
         if self._rx_buf.find("MSG:",0,4) == -1:
-            self._log.debug("START MESSAGE: %s", self._rx_buf.rstrip())
+            self._log.info("START MESSAGE: %s", self._rx_buf.rstrip())
             self._rx_buf = ''
             return False
 

--- a/src/interfacers/EmonHubTx3eInterfacer.py
+++ b/src/interfacers/EmonHubTx3eInterfacer.py
@@ -47,10 +47,17 @@ class EmonHubTx3eInterfacer(ehi.EmonHubSerialInterfacer):
 
         # If line incomplete, exit
         if '\r\n' not in self._rx_buf:
+            self._rx_buf = ''
             return
 
         # Remove CR,LF
         f = self._rx_buf[:-2].strip()
+
+        #Check message string for data else publish startup messages from EmonTX
+        if f.find("MSG:",0,4) == -1:
+            self._log.debug("START MESSAGE: %s", f)
+            self._rx_buf = ''
+            return False
 
         # Create a Payload object
         c = Cargo.new_cargo(rawdata=f)

--- a/src/interfacers/EmonHubTx3eInterfacer.py
+++ b/src/interfacers/EmonHubTx3eInterfacer.py
@@ -47,17 +47,21 @@ class EmonHubTx3eInterfacer(ehi.EmonHubSerialInterfacer):
 
         # If line incomplete, exit
         if '\r\n' not in self._rx_buf:
+            # If string longer than 3 print message
+            if len(self._rx_buf) > 3:
+                self._log.debug("START MESSAGE: %s", self._rx_buf.rstrip())
+
             self._rx_buf = ''
-            return
+            return False
+
+        #Check for MSG data string. If not found...
+        if self._rx_buf.find("MSG:",0,4) == -1:
+            self._log.debug("START MESSAGE: %s", self._rx_buf.rstrip())
+            self._rx_buf = ''
+            return False
 
         # Remove CR,LF
         f = self._rx_buf[:-2].strip()
-
-        #Check message string for data else publish startup messages from EmonTX
-        if f.find("MSG:",0,4) == -1:
-            self._log.info("START MESSAGE: %s", f)
-            self._rx_buf = ''
-            return False
 
         # Create a Payload object
         c = Cargo.new_cargo(rawdata=f)


### PR DESCRIPTION
If the EmonTX is reset, the interfacer trys to interpret the incoming serial lines as data messages. This can result in spurious inputs being created.

By checking for the string "MSG:" in the decoded text, this can be avoided.

As a bonus, the initial output from the EmonTX can be recorded.

I have also reset the buffer at line 50. I think this is more correct.

I also query why this return does not return `False`

Output seen in `emonhub.log` to first MSG

```
2021-01-16 11:27:16,062 DEBUG    SerialTx   START MESSAGE: emonTx V3.4 EmonLibCM Continuous Monitoring V1.80
2021-01-16 11:27:16,171 DEBUG    SerialTx   START MESSAGE: OpenEnergyMonitor.org
2021-01-16 11:27:16,279 DEBUG    SerialTx   START MESSAGE: Loaded EEPROM config
2021-01-16 11:27:16,385 DEBUG    SerialTx   START MESSAGE: Settings:
2021-01-16 11:27:16,707 DEBUG    SerialTx   START MESSAGE: Calibration:
2021-01-16 11:27:16,821 DEBUG    SerialTx   START MESSAGE: vCal = 268.97
2021-01-16 11:27:16,932 DEBUG    SerialTx   START MESSAGE: i1Cal = 90.90
2021-01-16 11:27:17,041 DEBUG    SerialTx   START MESSAGE: i1Lead = 4.20
2021-01-16 11:27:17,172 DEBUG    SerialTx   START MESSAGE: i2Cal = 90.90
2021-01-16 11:27:17,289 DEBUG    SerialTx   START MESSAGE: i2Lead = 4.20
2021-01-16 11:27:17,396 DEBUG    SerialTx   START MESSAGE: i3Cal = 90.90
2021-01-16 11:27:17,502 DEBUG    SerialTx   START MESSAGE: i3Lead = 4.20
2021-01-16 11:27:17,611 DEBUG    SerialTx   START MESSAGE: i4Cal = 16.67
2021-01-16 11:27:17,718 DEBUG    SerialTx   START MESSAGE: i4Lead = 6.00
2021-01-16 11:27:17,835 DEBUG    SerialTx   START MESSAGE: datalog = 10.01
2021-01-16 11:27:17,958 DEBUG    SerialTx   START MESSAGE: pulses = 1
2021-01-16 11:27:18,078 DEBUG    SerialTx   START MESSAGE: pulse period = 100
2021-01-16 11:27:18,185 DEBUG    SerialTx   START MESSAGE: temp_enable = 1
2021-01-16 11:27:18,319 DEBUG    SerialTx   START MESSAGE: Temperature Sensors found = 0 of 1
2021-01-16 11:27:18,442 DEBUG    SerialTx   START MESSAGE: Temperature measurement is NOT enabled.
2021-01-16 11:27:18,547 DEBUG    SerialTx   START MESSAGE:
2021-01-16 11:27:18,763 DEBUG    SerialTx   START MESSAGE: POST.....wait 10s
2021-01-16 11:27:18,880 DEBUG    SerialTx   START MESSAGE: '+++' then [Enter] for config mode
2021-01-16 11:27:26,093 DEBUG    SerialTx   START MESSAGE: CT1 detected, i1Cal:90.90
2021-01-16 11:27:36,544 DEBUG    SerialTx   START MESSAGE: AC present
2021-01-16 11:27:36,659 DEBUG    SerialTx   5 NEW FRAME : MSG:1,Vrms:241.01,P1:1046,E1:2,pulse:1
```
