### PR TITLE
Update device tree overlays names

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,8 +29,8 @@ if [ "$emonSD_pi_env" = "1" ]; then
 
     # RaspberryPi Serial configuration
     # disable Pi3 Bluetooth and restore UART0/ttyAMA0 over GPIOs 14 & 15;
-    # Review should this be: dtoverlay=pi3-miniuart-bt?
-    sudo sed -i -n '/dtoverlay=pi3-disable-bt/!p;$a dtoverlay=pi3-disable-bt' /boot/config.txt
+    # Review should this be: dtoverlay=miniuart-bt?
+    sudo sed -i -n '/dtoverlay=disable-bt/!p;$a dtoverlay=disable-bt' /boot/config.txt
 
     # We also need to stop the Bluetooth modem trying to use UART
     sudo systemctl disable hciuart


### PR DESCRIPTION
The previously named pi3-* device tree overlays got the pi3- prefix removed when Raspberry Pi 4 was released: https://github.com/raspberrypi/firmware/commit/910297737865b68d64f8419a92327a03ac04b72d

The old names are still kept valid for backwards compatibility, but this this commit applies the new names, to keep the script future-prove.