### PR TITLE
Emoncms HTTP interfacer option to send names and send as compressed binary

### DIFF
--- a/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
+++ b/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
@@ -4,6 +4,7 @@ import time
 import json
 import requests
 import zlib
+from binascii import hexlify
 from emonhub_interfacer import EmonHubInterfacer
 
 class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
@@ -68,7 +69,7 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
             
             if self._settings['compress']:
                 # Compress data and encode as hex string.
-                post_body_data["data"] = zlib.compress(post_body_data["data"]).encode("hex")
+                post_body_data["data"] = hexlify(zlib.compress(post_body_data["data"].encode()))
                 # Set flag.
                 post_body_data["c"] = 1
             
@@ -146,7 +147,7 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
                 self._settings[key] = int(setting)
                 continue
             elif key == 'compress':
-                self._log.info("Setting " + self.name + " compress: " + setting)
+                self._log.info("Setting " + self.name + " compress: " + str(setting))
                 self._settings[key] = bool(int(setting))
                 continue
             else:

--- a/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
+++ b/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
@@ -125,7 +125,9 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
             
             result = False
             try:
+                st = time.time()
                 reply = requests.post(post_url, post_body, timeout=60, headers={'Authorization': 'Bearer '+self._settings['apikey']})
+                dt = (time.time()-st)*1000
                 reply.raise_for_status()  # Raise an exception if status code isn't 200
                 result = reply.text
             except requests.exceptions.RequestException as ex:
@@ -133,7 +135,7 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
                 return False
 
             if result == 'ok':
-                self._log.debug("acknowledged receipt with '%s' from %s", result, self._settings['url'])
+                self._log.debug("acknowledged receipt with '%s' from %s (%d ms)", result, self._settings['url'], dt)
                 return True
             else:
                 self._log.warning("send failure: wanted 'ok' but got '%s'", result)

--- a/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
+++ b/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
@@ -147,11 +147,7 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
                 continue
             elif key == 'compress':
                 self._log.info("Setting " + self.name + " compress: " + setting)
-                if setting == "1":
-                    setting = True
-                else:
-                    setting = False
-                self._settings[key] = setting
+                self._settings[key] = bool(int(setting))
                 continue
             else:
                 self._log.warning("'%s' is not valid for %s: %s", setting, self.name, key)

--- a/src/interfacers/EmonHubSocketInterfacer.py
+++ b/src/interfacers/EmonHubSocketInterfacer.py
@@ -26,7 +26,7 @@ class EmonHubSocketInterfacer(EmonHubInterfacer):
         self._settings.update(self._skt_settings)
 
         # Open socket
-        self._socket = self._open_socket(port_nb)
+        self._socket = self._open_socket(int(port_nb))
 
         # Initialize RX buffer for socket
         self._sock_rx_buf = ''


### PR DESCRIPTION
This pull request incorporates https://github.com/openenergymonitor/emonhub/pull/70 by @SeanDS and https://github.com/openenergymonitor/emonhub/pull/55 by @anbugge adding the ability to send input names alongside values to emoncms with gz compression.

Interestingly testing a couple of different formats for sending bulk data with compression suggests that, the at first glance, relatively inefficient json with names repeated for each frame actually ends up compressing better than alternative approaches.
I will post the different tests I did below