### PR TITLE
Use a requests.Session to reuse HTTP connections

### DIFF
--- a/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
+++ b/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
@@ -33,6 +33,8 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
         # maximum buffer size
         self.buffer._maximumEntriesInBuffer = 100000
 
+        self.session = requests.Session()
+
     def _process_post(self, databuffer):
         """Send data to server."""
 
@@ -63,7 +65,7 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
             
             result = False
             try:
-                reply = requests.post(post_url, {'apikey': self._settings['apikey'], 'data': data_string, 'sentat': str(sentat)}, timeout=60)
+                reply = self.session.post(post_url, {'apikey': self._settings['apikey'], 'data': data_string, 'sentat': str(sentat)}, timeout=60)
                 reply.raise_for_status()  # Raise an exception if status code isn't 200
                 result = reply.text
             except requests.exceptions.RequestException as ex:
@@ -83,7 +85,7 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
             self._log.info("sending: " + post_url + "E-M-O-N-C-M-S-A-P-I-K-E-Y")
             post_url = post_url + self._settings['apikey']
             try:
-                reply = requests.get(post_url, timeout=60)
+                reply = self.session.get(post_url, timeout=60)
                 reply.raise_for_status()
                 # self._log.debug(reply.text)
             except requests.exceptions.RequestException as ex:


### PR DESCRIPTION
once the server supports it. Until that happens this is a harmless change. Requests will notice the connection has been dropped and automatically make a new one.