### PR TITLE
Interfacer for Jaguar Land Rover Cars

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This version of emonhub is based on [@pb66 Paul Burnell's](https://github.com/pb
 - [MBUS Interfacer](conf/interfacer_examples/MBUS)
 - [Redis Interfacer](conf/interfacer_examples/Redis)
 - [Influx Interfacer](conf/interfacer_examples/Influx)
+- [Jaguar Land Rover Interfacer (added by @dconlon)](conf/interfacer_examples/JaguarLandRover)
 
 
 ***

--- a/conf/interfacer_examples/JaguarLandRover/jlr.emonhub.conf
+++ b/conf/interfacer_examples/JaguarLandRover/jlr.emonhub.conf
@@ -1,0 +1,17 @@
+#######################################################################
+#######################      emonhub.conf     #########################
+#######################################################################
+
+[interfacers]
+
+### Retrieves data from the Jaguar Land Rover API for electric car monitoring
+[[JaguarLandRover]]
+    Type = EmonHubJaguarLandRoverInterfacer
+    [[[init_settings]]]
+        timeinverval = 600
+        duringchargetimeinterval = 60
+        nodeid = 28
+        jlrusername = USERNAMEGOESHERE
+        jlrpassword = PASSWORDGOESHERE
+    [[[runtimesettings]]]
+        pubchannels = ToEmonCMS,

--- a/conf/interfacer_examples/JaguarLandRover/readme.md
+++ b/conf/interfacer_examples/JaguarLandRover/readme.md
@@ -1,0 +1,51 @@
+# Jaguar Land Rover Interfacer #
+
+This interfacer collects data from Jagular Land Rover's InControl API.  Data collected on vehicle state of charge is suitable for use with OpenEVSE via MQTT. 
+
+Tested with Range Rover Velar PHEV.  
+
+## Readings ##
+
+The following values (in order) are determined from the Jaguar Land Rover API.
+
+* ODOMETER_MILES
+* EV_STATE_OF_CHARGE
+* EV_RANGE_ON_BATTERY_MILES
+* EV_RANGE_ON_BATTERY_KM
+* EV_CHARGING_RATE_SOC_PER_HOUR
+* EV_SECONDS_TO_FULLY_CHARGED
+* EV_CHARGING_STATUS (1 or 0)
+
+## Sample config for emonhub.conf ##
+
+Sample configuration, add these settings under the [interfacers] tag.   Changing username and password to match those for your account on https://incontrol.landrover.com/
+
+```
+[[JaguarLandRover]]
+    Type = EmonHubJaguarLandRoverInterfacer
+    [[[init_settings]]]
+        timeinverval = 600
+        duringchargetimeinterval = 60
+        nodeid = 28
+        jlrusername = USERNAMEGOESHERE
+        jlrpassword = PASSWORDGOESHERE
+    [[[runtimesettings]]]
+        pubchannels = ToEmonCMS,
+```
+
+## Settings ##
+
+### timeinverval ###
+Interval between taking readings from API.  Normally 10 minutes (600 seconds)
+
+### duringchargetimeinterval ###
+When charging the API updates more frequently, so update every 1 minute when charging is detected (60 seconds)
+
+### nodeid ###
+The emonHub/emonCMS nodeId to use
+
+### jlrusername ###
+Username as used in the https://incontrol.landrover.com/ site
+
+### jlrpassword ###
+Password as used in the https://incontrol.landrover.com/ site

--- a/configuration.md
+++ b/configuration.md
@@ -257,6 +257,7 @@ In addition to the above core interfacers used as part of the core OpenEnergyMon
 - [SDM120-Modbus Interfacer](conf/interfacer_examples/SDM120)
 - [MBUS Interfacer](conf/interfacer_examples/MBUS)
 - [Redis Interfacer](conf/interfacer_examples/Redis)
+- [Jaguar Land Rover Interfacer](conf/interfacer_examples/JaguarLandRover)
 
 ***
 

--- a/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
+++ b/src/interfacers/EmonHubEmoncmsHTTPInterfacer.py
@@ -46,7 +46,12 @@ class EmonHubEmoncmsHTTPInterfacer(EmonHubInterfacer):
             return True
 
         if self._settings['senddata']:
-            data_string = json.dumps(databuffer, separators=(',', ':'))
+            # Set allow_nan=False as NaN would be rejected by emoncms.  NaN now
+            # causes ValueError exception which is unhandled, causing emonhub to
+            # exit and be restarted by supervisord which is preferable to a NaN
+            # from LeChacal RPICT7V1 blocking emonhub buffer and no data getting to
+            # EmonCMS.
+            data_string = json.dumps(databuffer, separators=(',', ':'), allow_nan=False)
 
             # Prepare URL string of the form
             # http://domain.tld/emoncms/input/bulk.json?apikey=12345

--- a/src/interfacers/EmonHubJaguarLandRoverInterfacer.py
+++ b/src/interfacers/EmonHubJaguarLandRoverInterfacer.py
@@ -118,8 +118,7 @@ class EmonHubJaguarLandRoverInterfacer(EmonHubInterfacer):
             names = []
             values = []
 
-            # TODO: add FUEL_LEVEL_PERC
-            for key in ['ODOMETER_MILES','EV_STATE_OF_CHARGE','EV_RANGE_ON_BATTERY_MILES','EV_RANGE_ON_BATTERY_KM','EV_CHARGING_RATE_SOC_PER_HOUR']:
+            for key in ['ODOMETER_MILES','EV_STATE_OF_CHARGE','EV_RANGE_ON_BATTERY_MILES','EV_RANGE_ON_BATTERY_KM','EV_CHARGING_RATE_SOC_PER_HOUR','FUEL_LEVEL_PERC']:
                 names.append(key)
                 if key in statusDict:
                     self._log.info("%s = %s", key, statusDict[key])

--- a/src/interfacers/EmonHubJaguarLandRoverInterfacer.py
+++ b/src/interfacers/EmonHubJaguarLandRoverInterfacer.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python3
+# EmonHubJaguarLandRoverInterfacer released for use by OpenEnergyMonitor project
+# GNU GENERAL PUBLIC LICENSE -  Version 2, June 1991
+# See LICENCE and README file for details
+
+# Inspiration taken from Stuart Pittaway's EmonHubBMWInterfacer
+
+__author__ = 'Dan Conlon'
+
+import jlrpy
+import sys
+import time
+import traceback
+import Cargo
+from emonhub_interfacer import EmonHubInterfacer
+
+"""class EmonHubJaguarLandRoverInterfacer
+
+Monitors car metrics via Jaguar Land Rover API
+
+"""
+
+class EmonHubJaguarLandRoverInterfacer(EmonHubInterfacer):
+
+    def __init__(self, name, jlrusername='', jlrpassword='', timeinverval=600, duringchargetimeinterval=60, nodeid=28):
+        """Initialize interfacer"""
+
+        # Initialization
+        super().__init__(name)
+
+        self._NodeId = int(nodeid)
+        self._Username = jlrusername
+        self._Password = jlrpassword
+
+        self._time_inverval = int(timeinverval)
+        self._time_inverval_during_charge = int(duringchargetimeinterval)
+        self._reset_duration_timer()
+
+        self._NodeName = name
+        self._first_time_loop = True
+        self._chargingStatus = "UNKNOWN"
+
+# TODO: funnel log lines to emonlogging
+        self._jlrConnection = jlrpy.Connection(self._Username, self._Password)
+
+    def close(self):
+        """Close"""
+        return
+
+    def _reset_duration_timer(self):
+        """Reset timer to current date/time"""
+        self._last_time_reading = time.time()
+
+    def _is_it_time(self):
+        """Checks to see if the duration has expired
+
+        Return true or false
+
+        """
+        duration_of_delay = time.time() - self._last_time_reading
+
+        # CHARGINGACTIVE/NOCHARGING
+        if self._chargingStatus == "CHARGING":
+            # Charging in progress
+            waittime = self._time_inverval_during_charge
+        else:
+            # Not charging
+            waittime = self._time_inverval
+
+        return int(duration_of_delay) > waittime
+
+    # Override base _process_rx code from emonhub_interfacer
+    def _process_rx(self, rxc):
+        if not rxc:
+            return False
+
+        return rxc
+
+    # Override base read code from emonhub_interfacer
+    def read(self):
+        """Read data from JLR API"""
+
+        #Wait until we are ready to read from inverter
+        if not self._is_it_time() and not self._first_time_loop:
+            return
+
+        self._reset_duration_timer()
+
+        self._first_time_loop = False
+
+        try:
+            # Select the first vehicle in the account
+            vehicle = self._jlrConnection.vehicles[0]
+            self._log.debug("Fetching status of VIN %s", vehicle.vin)
+
+            statusResponse = vehicle.get_status()
+
+            coreStatusList = statusResponse['vehicleStatus']['coreStatus']
+            evStatusList = statusResponse['vehicleStatus']['evStatus']
+            statusList = coreStatusList + evStatusList
+            statusDict = {d['key']: d['value'] for d in statusList}
+
+            names = []
+            values = []
+
+            for key in ['ODOMETER_MILES','EV_STATE_OF_CHARGE','EV_RANGE_ON_BATTERY_MILES','EV_RANGE_ON_BATTERY_KM','EV_CHARGING_RATE_SOC_PER_HOUR']:
+                names.append(key)
+                if key in statusDict:
+                    self._log.debug("%s = %s", key, statusDict[key])
+                    values.append(float(statusDict[key]))
+                else:
+                    values.append(-1)
+
+            # OpenEVSE expects charge remaining time in seconds
+            names.append('EV_SECONDS_TO_FULLY_CHARGED')
+            if 'EV_MINUTES_TO_FULLY_CHARGED' in statusDict:
+                self._log.debug("%s = %s", 'EV_MINUTES_TO_FULLY_CHARGED', statusDict['EV_MINUTES_TO_FULLY_CHARGED'])
+                values.append(float(statusDict['EV_MINUTES_TO_FULLY_CHARGED']) * 60)
+            else:
+                values.append(-1)
+
+            # Store if the car is charging or not
+            if 'EV_CHARGING_STATUS' in statusDict:
+                self._log.debug("%s = %s", 'EV_CHARGING_STATUS', statusDict['EV_CHARGING_STATUS'])
+                self._chargingStatus = statusDict['EV_CHARGING_STATUS']
+            names.append("EV_CHARGING_STATUS")
+            if self._chargingStatus == "CHARGING":
+                values.append(1)
+            else:
+                values.append(0)
+
+            c = Cargo.new_cargo()
+            c.rawdata = None
+            c.realdata = values
+            c.names = names
+
+            c.nodeid = self._NodeId
+            c.nodename = self._NodeName
+
+            return c
+
+        except Exception as err2:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            self._log.error(err2)
+            self._log.error(repr(traceback.format_exception(exc_type, exc_value, exc_traceback)))

--- a/src/interfacers/EmonHubJaguarLandRoverInterfacer.py
+++ b/src/interfacers/EmonHubJaguarLandRoverInterfacer.py
@@ -3,7 +3,8 @@
 # GNU GENERAL PUBLIC LICENSE -  Version 2, June 1991
 # See LICENCE and README file for details
 
-# Inspiration taken from Stuart Pittaway's EmonHubBMWInterfacer
+# Inspiration taken from Stuart Pittaway's EmonHubBMWInterfacer. With thanks
+# to @ardevd for jlrpy python library for interacting with the JLR's API.
 
 __author__ = 'Dan Conlon'
 

--- a/src/interfacers/EmonHubMBUSInterfacer.py
+++ b/src/interfacers/EmonHubMBUSInterfacer.py
@@ -377,7 +377,7 @@ class EmonHubMBUSInterfacer(EmonHubInterfacer):
     def request_data(self, address, records):
         for i in range(0,2):
             self.mbus_short_frame(address, 0x5b)
-            time.sleep(1.0)
+            # time.sleep(1.0)
             result = self.read_data_frame(records)
             if result!=None:
                 return result
@@ -387,7 +387,7 @@ class EmonHubMBUSInterfacer(EmonHubInterfacer):
     def request_data_sdm120(self, address, records):
         for i in range(0,2):
             self.mbus_request_sdm120(address)
-            time.sleep(1.0)
+            # time.sleep(1.0)
             result = self.read_data_frame(records)
             if result!=None:
                 return result
@@ -404,53 +404,57 @@ class EmonHubMBUSInterfacer(EmonHubInterfacer):
         valid = False
         
         start_time = time.time()
+        
         val = 0
-        while self.ser.in_waiting:
-            # Read in byte
-            val = ord(self.ser.read(1))
-            data.append(val)
-            # print(str(bid)+" "+str(val)+" "+str(hex(val)))
-            # Long frame start, reset checksum
-            if bid == 0 and val == 0x68:
-                # print("MBUS start")
-                valid = True
-                checksum = 0
+        
+        while (time.time()-start_time)<2.0:
+            while self.ser.in_waiting:
+                # Read in byte
+                val = ord(self.ser.read(1))
+                data.append(val)
+                # print(str(bid)+" "+str(val)+" "+str(hex(val)))
+                # Long frame start, reset checksum
+                if bid == 0 and val == 0x68:
+                    # print("MBUS start")
+                    valid = True
+                    checksum = 0
 
-            # 2nd byte is the frame length
-            if valid and bid == 1:
-                length = val
-                bid_end = length + 4 + 2 - 1
-                bid_checksum = bid_end - 1
-                # print("MBUS length "+str(length))
-                # print("MBUS bid_end "+str(bid_end))
-                # print("MBUS bid_checksum "+str(bid_checksum))
+                # 2nd byte is the frame length
+                if valid and bid == 1:
+                    length = val
+                    bid_end = length + 4 + 2 - 1
+                    bid_checksum = bid_end - 1
+                    # print("MBUS length "+str(length))
+                    # print("MBUS bid_end "+str(bid_end))
+                    # print("MBUS bid_checksum "+str(bid_checksum))
 
-            if valid and bid == 2 and val != length:
-                valid = False                       # 3rd byte is also length, check that its the same as 2nd byte
-            if valid and bid == 3 and val != 0x68:
-                valid = False                         # 4th byte is the start byte again
-            if valid and bid > 3 and bid < bid_checksum:
-                checksum += val                 # Increment checksum during data portion of frame
+                if valid and bid == 2 and val != length:
+                    valid = False                       # 3rd byte is also length, check that its the same as 2nd byte
+                if valid and bid == 3 and val != 0x68:
+                    valid = False                         # 4th byte is the start byte again
+                if valid and bid > 3 and bid < bid_checksum:
+                    checksum += val                 # Increment checksum during data portion of frame
 
-            if valid and bid == bid_checksum and val != checksum % 256:
-                if self._settings['validate_checksum']: 
-                    valid = False  # Validate checksum
-                    
-            if bid == bid_end and val == 0x16:
-                time_elapsed = time.time()-start_time
-                self._log.debug("MBUS data received "+str(bid)+" bytes "+str(time_elapsed)+"s")
+                if valid and bid == bid_checksum and val != checksum % 256:
+                    if self._settings['validate_checksum']: 
+                        valid = False  # Validate checksum
                         
-                if valid: # Parse frame if still valid
-                    if self.use_meterbus_lib:
-                        return self.parse_frame_meterbus_lib(data,records)
-                    else:
-                        return self.parse_frame(data,records)
+                if bid == bid_end and val == 0x16:
+                    time_elapsed = time.time()-start_time
+                    self._log.debug("Invalid MBUS data received %d bytes %0.1f ms" % (bid,time_elapsed*1000))
+                            
+                    if valid: # Parse frame if still valid
+                        if self.use_meterbus_lib:
+                            return self.parse_frame_meterbus_lib(data,records)
+                        else:
+                            return self.parse_frame(data,records)
 
-            bid += 1
+                bid += 1
+            time.sleep(0.1)
             
         # If we are here data response is corrupt
         time_elapsed = time.time()-start_time
-        self._log.debug("Invalid MBUS data received "+str(bid)+" bytes "+str(time_elapsed)+"s")       
+        self._log.debug("Invalid MBUS data received %d bytes %0.1f ms" % (bid,time_elapsed*1000))       
         # end of read_data_frame
 
     def add_result_to_cargo(self,meter,c,result):

--- a/src/interfacers/__init__.py
+++ b/src/interfacers/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "EmonHubSMASolarInterfacer",
     "EmonHubGraphiteInterfacer",
     "EmonHubBMWInterfacer",
+    "EmonHubJaguarLandRoverInterfacer",
     "EmonModbusTcpInterfacer",
     "EmonHubTeslaPowerWallInterfacer",
     "EmonHubSDS011Interfacer",


### PR DESCRIPTION
Emonhub interfacer for fetching data about a Jaguar Land Rover (JLR) vehicle from JLR's InControl API.  Data collected on vehicle state of charge is suitable for use with (and has been tested with) OpenEVSE via MQTT.

Based on @stuartpittaway's EmonHubBMWInterfacer. Uses @ardevd's jlrpy for interacting with the JLR API.

Tested with Range Rover Velar PHEV.