### PR TITLE
Allow emonhub to run on systems without /opt/.../available.conf

### DIFF
--- a/src/emonhub.py
+++ b/src/emonhub.py
@@ -91,7 +91,7 @@ class EmonHub:
             eha.auto_conf_enabled = self.autoconf.enabled
         except eha.EmonHubAutoConfError as e:
             logger.error(e)
-            sys.exit("Unable to load available.conf")
+            self._exit = True # Exit process if main thread cannot start
         
     def run(self):
         """Launch the hub.

--- a/src/emonhub_auto_conf.py
+++ b/src/emonhub_auto_conf.py
@@ -61,15 +61,17 @@ class EmonHubAutoConf:
                 
         if self.enabled:
             self._log.debug("Automatic configuration of nodes enabled")
-        else:
-            self._log.debug("Automatic configuration of nodes disabled")    
                    
-        # Initialize attribute settings as a ConfigObj instance
-        try:
-            result = ConfigObj(filename, file_error=True)
-            self.available = self.prepare_available(result['available'])
-        except Exception as e:
-            raise EmonHubAutoConfError(e)
+            # Initialize attribute settings as a ConfigObj instance
+            try:
+                result = ConfigObj(filename, file_error=True)
+                self.available = self.prepare_available(result['available'])
+            except Exception as e:
+                raise EmonHubAutoConfError(e)
+                
+        else:
+            self._log.debug("Automatic configuration of nodes disabled")
+            self.available = None
 
     def prepare_available(self,nodes):
         for n in nodes:


### PR DESCRIPTION
emonhub tries to load available.conf from the fixed path /opt/openenergymonitor/emonhub/conf/available.conf even when autoconf = 0, resulting in an error being logged and and sys.exit being called.  sys.exit exits the main thread but not the emonhub process leaving the interfacer threads running without any main thread to transfer packets over the message bus between them.

These commits attempt to load available.conf only when autoconf is enabled and where autoconf is enabled and available.conf cannot be loaded ensure the whole process exits.