### PR TITLE
Emonhub log folder isn't currently created

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,10 +81,8 @@ fi
 if [ ! -d /etc/emonhub ]; then
     echo "Creating /etc/emonhub directory"
     sudo mkdir /etc/emonhub
-    sudo chown $user:root /var/log/emonhub
 else
     echo "/etc/emonhub directory already exists"
-    sudo chown $user:root /var/log/emonhub
 fi
 
 if [ ! -f /etc/emonhub/emonhub.conf ]; then
@@ -101,8 +99,13 @@ if [ ! -f /etc/emonhub/emonhub.conf ]; then
 fi
 
 # Fix emonhub log file permissions
-if [ -d /var/log/emonhub ]; then
-    echo "Setting ownership of /var/log/emonhub to $user"
+if [ ! -d /var/log/emonhub ]; then
+    echo "Creating log folder"
+    sudo mkdir /var/log/emonhub
+    echo "Setting ownership of /var/log/emonhub to $user:root"
+    sudo chown $user:root /var/log/emonhub
+else
+    echo "Setting ownership of /var/log/emonhub to $user:root"
     sudo chown $user:root /var/log/emonhub
 fi
 


### PR DESCRIPTION
The log folder is not being created. This is probably because under some circumstances emonhub creates it's own log.

However, this means that the service does not start as the log cannot be mounted before the system starts, so on first install requires the log folder to exist.

logrotate is also more picky about permissions so the folder needs to be `$USER:root` else the logs are not rotated.