### PR TITLE
MQTT JSON subscribe

### DIFF
--- a/examples/mqtt_pub_json_format.py
+++ b/examples/mqtt_pub_json_format.py
@@ -1,0 +1,13 @@
+import time
+import paho.mqtt.client as mqtt
+
+client = mqtt.Client()
+client.username_pw_set("emonpi", "emonpimqtt2016")
+client.connect("127.0.0.1", 1883, 60)
+
+while True:
+    topic = "zigbeemqtt/temp1"
+    payload = '{"battery":100,"humidity":80,"temperature":22,"voltage":3100}'
+    client.publish(topic, payload=payload, qos=0, retain=False)
+    # client.loop()
+    time.sleep(5.0)

--- a/examples/mqtt_pub_node_format.py
+++ b/examples/mqtt_pub_node_format.py
@@ -1,0 +1,13 @@
+import time
+import paho.mqtt.client as mqtt
+
+client = mqtt.Client()
+client.username_pw_set("emonpi", "emonpimqtt2016")
+client.connect("127.0.0.1", 1883, 60)
+
+while True:
+    topic = "emonhub/tx/30/values"
+    payload = "1,1850"
+    client.publish(topic, payload=payload, qos=0, retain=False)
+    # client.loop()
+    time.sleep(5.0)

--- a/examples/mqtt_pub_nodevar_format.py
+++ b/examples/mqtt_pub_nodevar_format.py
@@ -1,0 +1,13 @@
+import time
+import paho.mqtt.client as mqtt
+
+client = mqtt.Client()
+client.username_pw_set("emonpi", "emonpimqtt2016")
+client.connect("127.0.0.1", 1883, 60)
+
+while True:
+    topic = "zigbeemqtt/temp1/temperature"
+    payload = "18.5"
+    client.publish(topic, payload=payload, qos=0, retain=False)
+    # client.loop()
+    time.sleep(5.0)

--- a/src/interfacers/EmonHubMqttInterfacer.py
+++ b/src/interfacers/EmonHubMqttInterfacer.py
@@ -253,7 +253,7 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
             self._log.info("connection status: %s", connack_string[rc])
             self._connected = True
             # Subscribe to MQTT topics
-            if len(self._settings["pubchannels"]) and !len(self._settings["subchannels"]):
+            if len(self._settings["pubchannels"]) and not len(self._settings["subchannels"]):
                 if int(self._settings["nodevar_format_enable"]) == 1:
                     self._log.info("subscribe "+str(self._settings["nodevar_format_basetopic"]) + "#")
                     self._mqttc.subscribe(str(self._settings["nodevar_format_basetopic"]) + "#")

--- a/src/interfacers/EmonHubMqttInterfacer.py
+++ b/src/interfacers/EmonHubMqttInterfacer.py
@@ -255,14 +255,14 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
             # Subscribe to MQTT topics
             if len(self._settings["pubchannels"]) and not len(self._settings["subchannels"]):
                 if int(self._settings["nodevar_format_enable"]) == 1:
-                    self._log.info("subscribe "+str(self._settings["nodevar_format_basetopic"]) + "#")
-                    self._mqttc.subscribe(str(self._settings["nodevar_format_basetopic"]) + "#")
+                    self._log.info("subscribe "+str(self._settings["nodevar_format_basetopic"]))
+                    self._mqttc.subscribe(str(self._settings["nodevar_format_basetopic"]))
                 if int(self._settings["node_format_enable"]) == 1:
-                    self._log.info("subscribe "+str(self._settings["node_format_basetopic"]) + "#")
-                    self._mqttc.subscribe(str(self._settings["node_format_basetopic"]) + "#")
+                    self._log.info("subscribe "+str(self._settings["node_format_basetopic"]))
+                    self._mqttc.subscribe(str(self._settings["node_format_basetopic"]))
                 if int(self._settings["node_JSON_enable"]) == 1:
-                    self._log.info("subscribe "+str(self._settings["node_JSON_enable"]) + "#")
-                    self._mqttc.subscribe(str(self._settings["node_JSON_basetopic"]) + "#")
+                    self._log.info("subscribe "+str(self._settings["node_JSON_enable"]))
+                    self._mqttc.subscribe(str(self._settings["node_JSON_basetopic"]))
                          
         self._log.debug("CONACK => Return code: %d", rc)
 
@@ -284,7 +284,7 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
     
         # General MQTT format: emon/emonpi/power1 ... 100
         if int(self._settings["nodevar_format_enable"]) == 1:
-            if topic_parts[0] == self._settings["nodevar_format_basetopic"][:-1]:
+            # if topic_parts[0] == self._settings["nodevar_format_basetopic"][:-1]:
                 nodeid = topic_parts[1]
                 variable_name = "_".join(topic_parts[2:])
                 try:
@@ -299,7 +299,7 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
             
         # Emoncms nodes module format: emon/tx/10/values ... 100,200,300
         if int(self._settings["node_format_enable"]) == 1:
-            if topic_parts[0] == self._settings["node_format_basetopic"][:-1]:
+            # if topic_parts[0] == self._settings["node_format_basetopic"][:-1]:
                 if len(topic_parts)==4 and topic_parts[1] == "tx" and topic_parts[3] == "values":
                     nodeid = topic_parts[2]
                     payload = msg.payload.decode()
@@ -315,7 +315,7 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
                 
         # JSON format: zigbeemqtt/temp1 {"battery":100,"humidity":80,"temperature":22,"voltage":3100}
         if int(self._settings["node_JSON_enable"]) == 1:
-            if topic_parts[0] == self._settings["node_JSON_basetopic"][:-1]:
+            # if topic_parts[0] == self._settings["node_JSON_basetopic"][:-1]:
                 nodeid = topic_parts[1]
                 json_string = msg.payload.decode()
                 try:

--- a/src/interfacers/EmonHubMqttInterfacer.py
+++ b/src/interfacers/EmonHubMqttInterfacer.py
@@ -253,7 +253,7 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
             self._log.info("connection status: %s", connack_string[rc])
             self._connected = True
             # Subscribe to MQTT topics
-            if len(self._settings["pubchannels"]):
+            if len(self._settings["pubchannels"]) and !len(self._settings["subchannels"]):
                 if int(self._settings["nodevar_format_enable"]) == 1:
                     self._log.info("subscribe "+str(self._settings["nodevar_format_basetopic"]) + "#")
                     self._mqttc.subscribe(str(self._settings["nodevar_format_basetopic"]) + "#")

--- a/src/interfacers/EmonHubMqttInterfacer.py
+++ b/src/interfacers/EmonHubMqttInterfacer.py
@@ -52,7 +52,7 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
         # Add any MQTT specific settings
         self._mqtt_settings = {
             # emonhub/rx/10/values format - default emoncms nodes module
-            'node_format_enable': 1,
+            'node_format_enable': 0,
             'node_format_basetopic': 'emonhub/',
 
             # nodes/emontx/power1 format
@@ -73,6 +73,8 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
         })
 
         self._connected = False
+
+        print("here")
 
         self._mqttc = mqtt.Client()
         self._mqttc.on_connect = self.on_connect
@@ -119,6 +121,17 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
         # no time is transmitted to the subscribing clients
 
         # self.buffer.storeItem(f)
+
+    def read(self):
+        if not self._connected:
+            self._log.info("Connecting to MQTT Server")
+            try:
+                self._mqttc.username_pw_set(self.init_settings['mqtt_user'], self.init_settings['mqtt_passwd'])
+                self._mqttc.connect(self.init_settings['mqtt_host'], int(self.init_settings['mqtt_port']), 60)
+            except Exception:
+                self._log.info("Could not connect...")
+                time.sleep(1.0)  # FIXME why sleep? we're just about to return True
+
 
 
     def _process_post(self, databuffer):
@@ -242,8 +255,17 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
             self._log.info("connection status: %s", connack_string[rc])
             self._connected = True
             # Subscribe to MQTT topics
-            self._mqttc.subscribe(str(self._settings["node_format_basetopic"]) + "tx/#")
-
+            if len(self._settings["pubchannels"]):
+                if int(self._settings["nodevar_format_enable"]) == 1:
+                    self._log.info("subscribe "+str(self._settings["nodevar_format_basetopic"]) + "#")
+                    self._mqttc.subscribe(str(self._settings["nodevar_format_basetopic"]) + "#")
+                if int(self._settings["node_format_enable"]) == 1:
+                    self._log.info("subscribe "+str(self._settings["node_format_basetopic"]) + "#")
+                    self._mqttc.subscribe(str(self._settings["node_format_basetopic"]) + "#")
+                if int(self._settings["node_JSON_enable"]) == 1:
+                    self._log.info("subscribe "+str(self._settings["node_JSON_enable"]) + "#")
+                    self._mqttc.subscribe(str(self._settings["node_JSON_basetopic"]) + "#")
+                         
         self._log.debug("CONACK => Return code: %d", rc)
 
     def on_disconnect(self, client, userdata, rc):
@@ -256,33 +278,72 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
 
     def on_message(self, client, userdata, msg):
         topic_parts = msg.topic.split("/")
-        
-        if topic_parts[0] == self._settings["node_format_basetopic"][:-1]:
-            if topic_parts[1] == "tx":
-                if topic_parts[3] == "values":
-                    nodeid = int(topic_parts[2])
-                    
-                    payload = msg.payload,decode()
-                    realdata = payload.split(",")
-                    self._log.debug("Nodeid: "+str(nodeid)+" values: "+msg.payload)
 
+        self._log.debug("Received topic:"+str(msg.topic))
+        self._log.debug("Received payload:"+str(msg.payload.decode()))
+          
+        rxc = False
+    
+        # General MQTT format: emon/emonpi/power1 ... 100
+        if int(self._settings["nodevar_format_enable"]) == 1:
+            if topic_parts[0] == self._settings["nodevar_format_basetopic"][:-1]:
+                nodeid = topic_parts[1]
+                variable_name = "_".join(topic_parts[2:])
+                try:
+                    value = float(msg.payload.decode())
+                    realdata = [value]
                     rxc = Cargo.new_cargo(realdata=realdata)
-                    rxc.nodeid = nodeid
+                    rxc.nodeid = nodeid       
+                    rxc.names = [variable_name]
 
-                    if rxc:
-                        # rxc = self._process_tx(rxc)
-                        if rxc:
-                            for channel in self._settings["pubchannels"]:
-                            
-                                # Initialize channel if needed
-                                if not channel in self._pub_channels:
-                                    self._pub_channels[channel] = []
-                                    
-                                # Add cargo item to channel
-                                self._pub_channels[channel].append(rxc)
-                                
-                                self._log.debug(str(rxc.uri) + " Sent to channel' : " + str(channel))
-                                
+                except Exception:
+                    self._log.error("Payload format error")
+            
+        # Emoncms nodes module format: emon/tx/10/values ... 100,200,300
+        if int(self._settings["node_format_enable"]) == 1:
+            if topic_parts[0] == self._settings["node_format_basetopic"][:-1]:
+                if len(topic_parts)==4 and topic_parts[1] == "tx" and topic_parts[3] == "values":
+                    nodeid = topic_parts[2]
+                    payload = msg.payload.decode()
+                    realdata = payload.split(",")
+                    try:
+                        for i in range(0,len(realdata)):
+                            realdata[i] = float(realdata[i])
+                        
+                        rxc = Cargo.new_cargo(realdata=realdata)
+                        rxc.nodeid = nodeid
+                    except Exception:
+                        self._log.error("Payload format error")        
+                
+        # JSON format: zigbeemqtt/temp1 {"battery":100,"humidity":80,"temperature":22,"voltage":3100}
+        if int(self._settings["node_JSON_enable"]) == 1:
+            if topic_parts[0] == self._settings["node_JSON_basetopic"][:-1]:
+                nodeid = topic_parts[1]
+                json_string = msg.payload.decode()
+                try:
+                    json_data = json.loads(json_string)
+                    names = []
+                    values = []
+                    for key in json_data:
+                        names.append(key)
+                        values.append(json_data[key])
+                    rxc = Cargo.new_cargo(realdata=values)
+                    rxc.nodeid = nodeid   
+                    rxc.names = names
+                except Exception:     
+                    self._log.error("Payload JSON format error")                       
+        if rxc:
+            for channel in self._settings["pubchannels"]:
+            
+                # Initialize channel if needed
+                if not channel in self._pub_channels:
+                    self._pub_channels[channel] = []
+                    
+                # Add cargo item to channel
+                self._pub_channels[channel].append(rxc)
+                
+                self._log.debug(str(rxc.uri) + " Sent to channel' : " + str(channel))
+            
 
     def set(self, **kwargs):
         super().set(**kwargs)

--- a/src/interfacers/EmonHubMqttInterfacer.py
+++ b/src/interfacers/EmonHubMqttInterfacer.py
@@ -74,8 +74,6 @@ class EmonHubMqttInterfacer(EmonHubInterfacer):
 
         self._connected = False
 
-        print("here")
-
         self._mqttc = mqtt.Client()
         self._mqttc.on_connect = self.on_connect
         self._mqttc.on_disconnect = self.on_disconnect


### PR DESCRIPTION
Enable emonHub to subscribe to JSON MQTT topics, useful for integrating with [zigbee2mqtt](https://www.zigbee2mqtt.io/) and [Shelly WiFi sensors](https://community.openenergymonitor.org/t/shelly-plus-h-t-wireless-temperature-sensor-to-emoncms-via-mqtt/21991). 

e.g 

```
[[MQTT_sub1]
    Type = EmonHubMqttInterfacer
    [[[init_settings]]]
        mqtt_host = 127.0.0.1
        mqtt_port = 1883
        mqtt_user = emonpi
        mqtt_passwd = emonpimqtt2016
    [[[runtimesettings]]]
        pubchannels = ToEmonCMS,
        node_JSON_enable = 1
        node_JSON_basetopic = zigbee2mqtt/temp
```
The above emonhub config subscribes to MQTT topic `zigbee2mqtt/temp` and decodes the JSON message `{"battery":100,"humidity":72.23,"linkquality":116,"temperature":21.79,"voltage":3000}` which results in an input key called `temp` and Inputs with battery, humidity etc. 
