### PR TITLE
changed data pulled for kamstrup403

### DIFF
--- a/src/interfacers/EmonHubMBUSInterfacer.py
+++ b/src/interfacers/EmonHubMBUSInterfacer.py
@@ -565,7 +565,7 @@ class EmonHubMBUSInterfacer(EmonHubInterfacer):
                         result = self.request_data_sdm120(address,[1,7,11,23])
                         self.add_result_to_cargo(meter,c,result)
                     elif meter_type=="kamstrup403":
-                        result = self.request_data(address,[1,4,7,8,9,10,11,12,14])
+                        result = self.request_data(address,[1,10,11,12,13,14,15,16,19,26,27])
                         self.add_result_to_cargo(meter,c,result)
                         # ------------------------------------------------------
                             


### PR DESCRIPTION
Not sure if this is the proper way to do it, if not, please point me in the right direction. The dafault kamstrup403 data was lacking. This change gives more useful data for a heating/cooling meter

<img width="1493" alt="image" src="https://github.com/openenergymonitor/emonhub/assets/2983312/78cdd631-d230-4393-9708-1706da4cec2b">

btw, what is heatmeter_heat_calc?