### PR TITLE
Create emonhub.service.bullseye

### DIFF
--- a/service/emonhub.service.bullseye
+++ b/service/emonhub.service.bullseye
@@ -1,0 +1,23 @@
+[Unit]
+Description=emonHub data multiplexer
+# The config file lives in /etc/emonhub/emonhub.conf
+# The log file lives in /var/log/emonhub/emonhub.log
+After= network.target
+
+[Service]
+Type=exec
+ExecStart=/usr/local/bin/emonhub/emonhub.py --config-file=/etc/emonhub/emonhub.conf --logfile=/var/log/emonhub/emonhub.log
+User=pi
+Environment='USER=pi'
+Environment='LOG_PATH=/var/log/emonhub'
+PermissionsStartOnly=true
+ExecStartPre=/bin/mkdir -p ${LOG_PATH}
+ExecStartPre=/bin/chown ${USER} ${LOG_PATH}
+
+Restart=always
+RestartSec=5
+
+SyslogIdentifier=emonhub
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Create a service file for use with legacy Bullseye on PiZero without the requirement for `var-log.mount`. Do not understand why it is not made available, but it isn't.

Cannot be done via an add-in as you cannot remove requirements, just add them.

Could be automated via the install by checking hardware (as we do elsewhere) but low use case.