### PR TITLE
MBus Network

### DIFF
--- a/src/emonhub_interfacer.py
+++ b/src/emonhub_interfacer.py
@@ -112,7 +112,6 @@ class EmonHubInterfacer(threading.Thread):
         Any regularly performed tasks actioned here along with passing received values
 
         """
-
         while not self.stop:
 
             # Only read if there is a pub channel defined for the interfacer
@@ -306,7 +305,7 @@ class EmonHubInterfacer(threading.Thread):
         if node not in ehc.nodelist and self._settings['nodelistonly']:
             self._log.warning("%d Discarded RX frame not in nodelist, node:%s, length:%s bytes", cargo.uri, node, len(rxc.realdata))
             return False
-        
+
         # Data whitening uses for ensuring rfm sync
         if node in ehc.nodelist and 'rx' in ehc.nodelist[node] and 'whitening' in ehc.nodelist[node]['rx']:
             whitening = ehc.nodelist[node]['rx']['whitening']
@@ -647,7 +646,7 @@ class EmonHubInterfacer(threading.Thread):
             elif key == 'targeted' and str(setting).lower() in ['true', 'false']:
                 setting = str(setting).lower() == "true"
             elif key == 'nodelistonly' and str(setting).lower() in ['true', 'false','1','0']:
-                setting = str(setting).lower() == "true" or str(setting).lower() == "1"                
+                setting = str(setting).lower() == "true" or str(setting).lower() == "1"
             elif key == 'pubchannels':
                 pass
             elif key == 'subchannels':

--- a/src/interfacers/EmonHubMBUSInterfacer.py
+++ b/src/interfacers/EmonHubMBUSInterfacer.py
@@ -88,10 +88,7 @@ class EmonHubMBUSInterfacer(EmonHubInterfacer):
             if self.ping_address(self.ser, 1, 3):
                 self._log.info("ok ping")
             else:
-                print("no reply")
-
-            self._log.info("set")
-            self._log.info(self.ser)
+                self._log.info("no reply ping")
 
         except ModuleNotFoundError as err:
             self._log.error(err)


### PR DESCRIPTION
Extends EmonHubMBusInterfacer:

- Modify EmonHubMBusInterfacer.py to support network connection using meterbus_lib

- Modify EmonHubMBusInterfacer.py to return multiple cargo instance if nodename is empty. 
  In this case, emoncms inputs will show one category for each MBus Meter

- Modify emonhub_interfacer.py to support different type of result form interfacer : single cargo, list of cargo, 
  or dictionnary of cargo