### PR TITLE
[Feature] Add read-only ecoMain Modbus TCP interfacer

### DIFF
--- a/conf/interfacer_examples/ecomain/ecomain.emonhub.conf
+++ b/conf/interfacer_examples/ecomain/ecomain.emonhub.conf
@@ -1,0 +1,24 @@
+[[ecoMain]]
+    Type = EmonHubEcoMainInterfacer
+    [[[init_settings]]]
+        host = 192.168.1.50
+        serial = 001234567890
+        timeout = 3
+    [[[runtimesettings]]]
+        pubchannels = ToEmonCMS,
+        read_interval = 10
+        [[[[meters]]]]
+            [[[[[grid]]]]]
+                nodeid = 30
+                nodename = ecomain_grid
+                source = grid
+            [[[[[pv]]]]]
+                nodeid = 31
+                nodename = ecomain_pv
+                source = branches
+                phases = 0:1:false, 0:2:false, 0:3:false
+            [[[[[heatpump]]]]]
+                nodeid = 32
+                nodename = ecomain_heatpump
+                source = branches
+                phases = 1:4:true

--- a/conf/interfacer_examples/ecomain/readme.md
+++ b/conf/interfacer_examples/ecomain/readme.md
@@ -1,0 +1,56 @@
+# ecoMain Interfacer Configuration
+
+The ecoMain interfacer reads measurements from an ecoMain and its branch circuits over Modbus TCP and publishes logical meters to Emoncms. It does not provide a dedicated device wizard. In Emoncms, open `Setup > EmonHub > Edit Config`, copy the contents of [ecomain.emonhub.conf](ecomain.emonhub.conf) into the `interfacers` section, and adjust the settings for the local network and circuit allocation.
+
+## Devices and Logical Meters
+
+Each `EmonHubEcoMainInterfacer` instance represents one physical ecoMain device. Entries under `meters` are user-defined logical meter instances, not additional physical devices. Each logical meter appears on the Emoncms Inputs page under its own `nodeid` and `nodename`.
+
+- `source = grid` reads the ecoMain's fixed three-phase grid circuit. Do not configure `phases`. An interfacer may contain at most one `grid` logical meter.
+- `source = branches` combines physical branch circuits into a single-phase or three-phase logical meter. Each `phases` entry uses the `device:channel:invert` format. `device` must be `0..3` (`0` is the ecoMain and `1..3` are ecoSub 1..3), `channel` must be `1..10`, and `invert` must be `true` or `false`. One entry defines a single-phase meter; three entries define L1, L2, and L3 in configuration order.
+- A physical branch identified by the same `device:channel` pair cannot be assigned more than once, either across logical meters or within one logical meter. Every logical meter must have a unique `nodeid` and a unique `nodename`.
+- `nodename` is the node name published to MQTT and displayed on the Emoncms Inputs page. It may contain Unicode letters and digits, underscores, spaces, periods, and hyphens. It must not contain `/`, `#`, `+`, `:`, or other characters that affect MQTT routing or are rewritten by Emoncms. Do not duplicate these names in the global `[nodes]` section; the ecoMain interfacer preserves the configured logical meter name after standard emonHub receive processing.
+
+## Input Fields
+
+A single-phase logical meter publishes six fields in this fixed order:
+
+1. `power` (W)
+2. `energy` (kWh, imported active energy)
+3. `return_energy` (kWh, exported active energy)
+4. `voltage` (V)
+5. `current` (A)
+6. `power_factor` (dimensionless)
+
+A three-phase logical meter publishes 15 fields in this fixed order:
+
+1. `power` (W, total across all phases)
+2. `energy` (kWh, total imported active energy)
+3. `return_energy` (kWh, total exported active energy)
+4. `power_l1` (W)
+5. `power_l2` (W)
+6. `power_l3` (W)
+7. `voltage_l1` (V)
+8. `voltage_l2` (V)
+9. `voltage_l3` (V)
+10. `current_l1` (A)
+11. `current_l2` (A)
+12. `current_l3` (A)
+13. `power_factor_l1` (dimensionless)
+14. `power_factor_l2` (dimensionless)
+15. `power_factor_l3` (dimensionless)
+
+When a branch is configured with `invert = true`, the interfacer negates that phase's `power` and `power_factor` and swaps `energy` with `return_energy`. Voltage and current remain unchanged. For a three-phase branch meter, totals are calculated after applying this transformation to each phase.
+
+## Communication Scope and Limitations
+
+- The driver is read-only. It only reads holding registers using Modbus function code `03` and never writes registers. Register addresses are zero-based.
+- The TCP port is fixed at `502`, and the Modbus Unit ID is fixed at `255`; neither is configured in `init_settings`. `host` is the device address, `serial` is the 12-digit serial number printed on the device label (including leading zeroes), and `timeout` is the connection timeout.
+- After establishing a TCP connection, the driver validates, in order, that the model is `2401`, the ecoMain software version at address `3009` is at least `139`, and the device serial number exactly matches `serial`. If device information cannot be read or any validation fails, the driver closes the connection, publishes no measurements, and retries using the standard backoff mechanism.
+- The driver does not read ecoSub online status. If a branch device read fails, stale values must not be published as new Input data.
+- The model, serial number, and hardware/software/firmware versions are written only to the emonHub log and are not published as Inputs.
+- This integration does not provide OEM scheduling or control. It does not control EV chargers, heat pumps, or inverters.
+
+After saving the configuration, wait for data to appear on the standard Emoncms `Inputs` page. Configure a process list for each required Input and create or write to the corresponding `Feeds` there. The ecoMain interfacer does not create Feeds automatically.
+
+With the default emonPi/emonBase MQTT configuration, data is published in node-variable format as `emon/<nodename>/<inputname>`. The Emoncms MQTT subscriber uses these topics to create or update Inputs. `nodeid` remains the internal emonHub identifier used for compatibility processing, while the Inputs page groups nodes by `nodename`.

--- a/docs/emonhub-interfacers.md
+++ b/docs/emonhub-interfacers.md
@@ -6,6 +6,7 @@ github_url: "https://github.com/openenergymonitor/emonhub/blob/master/docs/emonh
 - [emonHub Interfacers](#emonhub-interfacers)
   - [List of Interfacers - (Links to GitHub)](#list-of-interfacers---links-to-github)
   - [Using emonHub](#using-emonhub)
+    - [ecoMain Modbus TCP energy meter](#ecomain-modbus-tcp-energy-meter)
     - [SDS011 Air-Quality sensor](#sds011-air-quality-sensor)
     - [Modbus Reader for Electric Meters](#modbus-electric-meters)
     - [Modbus Reader for Heat Meters](#modbus-heat-meters)
@@ -48,12 +49,17 @@ For a full list of interfacers, view GitHub source [https://github.com/openenerg
 - [RFM69 Interfacer](https://github.com/openenergymonitor/emonhub/tree/master/conf/interfacer_examples/RF69)
 - [Plum ecoNET 300 Interfacer](https://github.com/openenergymonitor/emonhub/tree/master/conf/interfacer_examples/Econet300)
 - [E+E Environmental Modbus Sensors Interfacer](https://github.com/openenergymonitor/emonhub/tree/master/conf/interfacer_examples/E%2BE)
+- [ecoMain Interfacer](../conf/interfacer_examples/ecomain/)
 
 ## Using emonHub
 
 Examples of using emonHub for specific purposes.
 
 **Important: ensure there is no conflic of ttyUSB ports between emonHub interfacers e.g by default there is a `EmonOEMInterfacer` which reads from ttyUSB0 which is used to read data from emonTx V4 if connected via USB, this interfacer will need to be removed to allow another interfacer eg SDM120 / MBUS etc to read from ttyUSB0**
+
+### ecoMain Modbus TCP energy meter
+
+In Emoncms, open `Setup > EmonHub > Edit Config` and add an `EmonHubEcoMainInterfacer` entry. See the [ecoMain example and configuration guide](../conf/interfacer_examples/ecomain/) for the complete configuration, logical-meter mapping, Inputs field order, and read-only limitations.
 
 ### SDS011 Air-Quality sensor
 

--- a/src/ecomain/__init__.py
+++ b/src/ecomain/__init__.py
@@ -1,0 +1,27 @@
+from .protocol import (
+    CURRENT_SCALE,
+    ENERGY_SCALE,
+    POWER_FACTOR_SCALE,
+    POWER_SCALE,
+    VOLTAGE_SCALE,
+    branch_addresses,
+    decode_i16,
+    decode_i32,
+    decode_text,
+    decode_u16,
+    decode_u64,
+)
+
+__all__ = [
+    "CURRENT_SCALE",
+    "ENERGY_SCALE",
+    "POWER_FACTOR_SCALE",
+    "POWER_SCALE",
+    "VOLTAGE_SCALE",
+    "branch_addresses",
+    "decode_i16",
+    "decode_i32",
+    "decode_text",
+    "decode_u16",
+    "decode_u64",
+]

--- a/src/ecomain/protocol.py
+++ b/src/ecomain/protocol.py
@@ -1,0 +1,195 @@
+import inspect
+
+
+POWER_SCALE = 0.01
+VOLTAGE_SCALE = 0.01
+CURRENT_SCALE = 0.01
+POWER_FACTOR_SCALE = 0.01
+ENERGY_SCALE = 0.000001
+
+GRID_BLOCKS = ((0, 32), (1000, 8), (1200, 9))
+
+
+def _decode_unsigned(registers):
+    value = 0
+    for offset, register in enumerate(registers):
+        value |= (register & 0xFFFF) << (16 * offset)
+    return value
+
+
+def _decode_signed(registers):
+    value = _decode_unsigned(registers)
+    bits = 16 * len(registers)
+    sign_bit = 1 << (bits - 1)
+    return (value ^ sign_bit) - sign_bit
+
+
+def decode_u16(registers):
+    return _decode_unsigned(registers)
+
+
+def decode_i16(registers):
+    return _decode_signed(registers)
+
+
+def decode_i32(registers):
+    return _decode_signed(registers)
+
+
+def decode_u64(registers):
+    return _decode_unsigned(registers)
+
+
+def decode_text(registers):
+    data = bytearray()
+    for register in registers:
+        data.extend((register & 0xFF, (register >> 8) & 0xFF))
+    return data.split(b"\x00", 1)[0].decode("ascii", errors="replace").strip()
+
+
+def branch_addresses(device, channel):
+    if device not in range(4) or channel not in range(1, 11):
+        raise ValueError("device must be 0..3 and channel must be 1..10")
+    offset = channel - 1
+    voltage = 1209 + 30 * device + 3 * offset
+    return {
+        "energy": 32 + 40 * device + 4 * offset,
+        "return_energy": 192 + 40 * device + 4 * offset,
+        "power": 1008 + 20 * device + 2 * offset,
+        "voltage": voltage,
+        "current": voltage + 1,
+        "power_factor": voltage + 2,
+    }
+
+
+class EcoMainReadError(Exception):
+    pass
+
+
+def _device_id_keyword(method):
+    try:
+        parameters = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        return "unit"
+    for keyword in ("device_id", "slave", "unit"):
+        if keyword in parameters:
+            return keyword
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    ):
+        return "unit"
+    raise EcoMainReadError("unsupported pymodbus client signature")
+
+
+class EcoMainReader:
+    def __init__(self, client, unit_id=255):
+        self._client = client
+        self._unit_id = unit_id
+        self._device_id_keyword = _device_id_keyword(
+            client.read_holding_registers
+        )
+
+    def _read(self, address, count):
+        try:
+            response = self._client.read_holding_registers(
+                address,
+                count=count,
+                **{self._device_id_keyword: self._unit_id},
+            )
+        except Exception as exc:
+            raise EcoMainReadError(
+                f"failed to read holding registers {address}:{count}"
+            ) from exc
+        if response.isError() or len(getattr(response, "registers", [])) != count:
+            raise EcoMainReadError(
+                f"invalid holding-register response {address}:{count}"
+            )
+        return response.registers
+
+    def read_grid(self):
+        energy, power, electric = (
+            self._read(address, count) for address, count in GRID_BLOCKS
+        )
+        phases = []
+        for phase in range(3):
+            power_offset = 2 * phase
+            electric_offset = 3 * phase
+            phases.append(
+                {
+                    "power": decode_i32(power[power_offset : power_offset + 2])
+                    * POWER_SCALE,
+                    "voltage": decode_u16(
+                        electric[electric_offset : electric_offset + 1]
+                    )
+                    * VOLTAGE_SCALE,
+                    "current": decode_u16(
+                        electric[electric_offset + 1 : electric_offset + 2]
+                    )
+                    * CURRENT_SCALE,
+                    "power_factor": decode_i16(
+                        electric[electric_offset + 2 : electric_offset + 3]
+                    )
+                    * POWER_FACTOR_SCALE,
+                }
+            )
+        return {
+            "power": decode_i32(power[6:8]) * POWER_SCALE,
+            "energy": decode_u64(energy[12:16]) * ENERGY_SCALE,
+            "return_energy": decode_u64(energy[28:32]) * ENERGY_SCALE,
+            "phases": phases,
+        }
+
+    def read_branch_device(self, device):
+        branch_addresses(device, 1)
+        forward = self._read(32 + 40 * device, 40)
+        reverse = self._read(192 + 40 * device, 40)
+        power = self._read(1008 + 20 * device, 20)
+        electric = self._read(1209 + 30 * device, 30)
+        samples = {}
+        for channel in range(1, 11):
+            energy_offset = 4 * (channel - 1)
+            power_offset = 2 * (channel - 1)
+            electric_offset = 3 * (channel - 1)
+            samples[channel] = {
+                "power": decode_i32(power[power_offset : power_offset + 2])
+                * POWER_SCALE,
+                "energy": decode_u64(forward[energy_offset : energy_offset + 4])
+                * ENERGY_SCALE,
+                "return_energy": decode_u64(
+                    reverse[energy_offset : energy_offset + 4]
+                )
+                * ENERGY_SCALE,
+                "voltage": decode_u16(
+                    electric[electric_offset : electric_offset + 1]
+                )
+                * VOLTAGE_SCALE,
+                "current": decode_u16(
+                    electric[electric_offset + 1 : electric_offset + 2]
+                )
+                * CURRENT_SCALE,
+                "power_factor": decode_i16(
+                    electric[electric_offset + 2 : electric_offset + 3]
+                )
+                * POWER_FACTOR_SCALE,
+            }
+        return samples
+
+    def read_device_info(self):
+        registers = self._read(3000, 14)
+        version_names = (
+            "hardware",
+            "ecomain_software",
+            "ecomain_firmware",
+            "ecosub_1_firmware",
+            "ecosub_2_firmware",
+            "ecosub_3_firmware",
+        )
+        return {
+            "model": decode_text(registers[0:2]),
+            "serial": decode_text(registers[2:8]),
+            "versions": {
+                name: decode_u16(registers[8 + offset : 9 + offset])
+                for offset, name in enumerate(version_names)
+            },
+        }

--- a/src/interfacers/EmonHubEcoMainInterfacer.py
+++ b/src/interfacers/EmonHubEcoMainInterfacer.py
@@ -1,0 +1,527 @@
+from collections import deque
+from collections.abc import Mapping
+import math
+import re
+import time
+
+import Cargo
+from emonhub_interfacer import EmonHubInterfacer
+
+try:
+    from pymodbus.client import ModbusTcpClient
+except ImportError:
+    try:
+        from pymodbus.client.sync import ModbusTcpClient
+    except ImportError:
+        ModbusTcpClient = None
+
+from ecomain.protocol import EcoMainReadError, EcoMainReader
+
+
+current_time = time.time
+
+
+SINGLE_PHASE_NAMES = (
+    "power",
+    "energy",
+    "return_energy",
+    "voltage",
+    "current",
+    "power_factor",
+)
+
+THREE_PHASE_NAMES = (
+    "power",
+    "energy",
+    "return_energy",
+    "power_l1",
+    "power_l2",
+    "power_l3",
+    "voltage_l1",
+    "voltage_l2",
+    "voltage_l3",
+    "current_l1",
+    "current_l2",
+    "current_l3",
+    "power_factor_l1",
+    "power_factor_l2",
+    "power_factor_l3",
+)
+
+ECOMAIN_PORT = 502
+ECOMAIN_UNIT_ID = 255
+EXPECTED_MODEL = "2401"
+MINIMUM_SOFTWARE_VERSION = 139
+
+
+class EcoMainConfigError(ValueError):
+    pass
+
+
+def _apply_invert(sample, invert):
+    result = dict(sample)
+    if invert:
+        result["power"] = -result["power"]
+        result["power_factor"] = -result["power_factor"]
+        result["energy"], result["return_energy"] = (
+            result["return_energy"],
+            result["energy"],
+        )
+    return result
+
+
+def _build_single_phase_cargo(meter, sample, timestamp):
+    values = [sample[name] for name in SINGLE_PHASE_NAMES]
+    return Cargo.new_cargo(
+        nodeid=meter["nodeid"],
+        nodename=meter["nodename"],
+        names=list(SINGLE_PHASE_NAMES),
+        realdata=values,
+        timestamp=timestamp,
+    )
+
+
+def _build_three_phase_cargo(meter, phases, timestamp, totals=None):
+    if len(phases) != 3:
+        raise EcoMainConfigError(
+            "three-phase cargo requires exactly three phases"
+        )
+
+    if totals is None:
+        totals = {
+            name: sum(phase[name] for phase in phases)
+            for name in ("power", "energy", "return_energy")
+        }
+
+    values = [
+        totals["power"],
+        totals["energy"],
+        totals["return_energy"],
+    ]
+    for name in ("power", "voltage", "current", "power_factor"):
+        values.extend(phase[name] for phase in phases)
+
+    return Cargo.new_cargo(
+        nodeid=meter["nodeid"],
+        nodename=meter["nodename"],
+        names=list(THREE_PHASE_NAMES),
+        realdata=values,
+        timestamp=timestamp,
+    )
+
+
+def _parse_phase(value):
+    parts = str(value).split(":")
+    if len(parts) != 3:
+        raise EcoMainConfigError(
+            "phase must use device:channel:invert format"
+        )
+
+    try:
+        device = int(parts[0])
+        channel = int(parts[1])
+    except (TypeError, ValueError) as exc:
+        raise EcoMainConfigError(
+            "phase device and channel must be integers"
+        ) from exc
+
+    invert_text = parts[2].lower()
+    if invert_text not in ("true", "false"):
+        raise EcoMainConfigError("phase invert must be true or false")
+    if device not in range(4):
+        raise EcoMainConfigError("phase device must be 0..3")
+    if channel not in range(1, 11):
+        raise EcoMainConfigError("phase channel must be 1..10")
+
+    return {
+        "device": device,
+        "channel": channel,
+        "invert": invert_text == "true",
+    }
+
+
+def _parse_meters(meters):
+    try:
+        entries = meters.items()
+    except AttributeError as exc:
+        raise EcoMainConfigError("meters must be a mapping") from exc
+
+    parsed = []
+    nodeids = set()
+    nodenames = set()
+    branches = set()
+    grid_count = 0
+
+    for meter_name, config in entries:
+        try:
+            nodeid = int(config.get("nodeid"))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise EcoMainConfigError(
+                f"meter {meter_name} nodeid must be an integer"
+            ) from exc
+        if nodeid in nodeids:
+            raise EcoMainConfigError(f"duplicate nodeid {nodeid}")
+
+        try:
+            raw_nodename = config.get("nodename")
+        except AttributeError as exc:
+            raise EcoMainConfigError(
+                f"meter {meter_name} must be a mapping"
+            ) from exc
+        nodename = "" if raw_nodename is None else str(raw_nodename).strip()
+        if not nodename:
+            raise EcoMainConfigError(f"meter {meter_name} nodename must not be empty")
+        if re.fullmatch(r"[\w .-]+", nodename) is None:
+            raise EcoMainConfigError(
+                f"meter {meter_name} nodename contains unsupported characters"
+            )
+        if nodename in nodenames:
+            raise EcoMainConfigError(f"duplicate nodename {nodename}")
+
+        source = str(config.get("source", "")).strip()
+        if source not in ("grid", "branches"):
+            raise EcoMainConfigError(
+                f"meter {meter_name} source must be grid or branches"
+            )
+
+        if source == "grid":
+            if "phases" in config:
+                raise EcoMainConfigError(
+                    f"grid meter {meter_name} must not define phases"
+                )
+            grid_count += 1
+            if grid_count > 1:
+                raise EcoMainConfigError("only one grid meter is allowed")
+            phases = ()
+        else:
+            if "phases" not in config:
+                raise EcoMainConfigError(
+                    f"branch meter {meter_name} must define phases"
+                )
+            raw_phases = config["phases"]
+            if isinstance(raw_phases, Mapping):
+                raise EcoMainConfigError(
+                    f"branch meter {meter_name} phases must be a string or list"
+                )
+            if isinstance(raw_phases, str):
+                raw_phases = [raw_phases]
+            try:
+                phase_count = len(raw_phases)
+            except TypeError as exc:
+                raise EcoMainConfigError(
+                    f"branch meter {meter_name} phases must be a list"
+                ) from exc
+            if phase_count not in (1, 3):
+                raise EcoMainConfigError(
+                    f"branch meter {meter_name} must define one or three phases"
+                )
+
+            parsed_phases = []
+            for raw_phase in raw_phases:
+                phase = _parse_phase(raw_phase)
+                branch = (phase["device"], phase["channel"])
+                if branch in branches:
+                    raise EcoMainConfigError(
+                        f"branch {branch[0]}:{branch[1]} is used more than once"
+                    )
+                branches.add(branch)
+                parsed_phases.append(phase)
+            phases = tuple(parsed_phases)
+
+        nodeids.add(nodeid)
+        nodenames.add(nodename)
+        parsed.append(
+            {
+                "name": str(meter_name),
+                "nodeid": nodeid,
+                "nodename": nodename,
+                "source": source,
+                "phases": phases,
+            }
+        )
+
+    if not parsed:
+        raise EcoMainConfigError("at least one meter must be configured")
+    return tuple(parsed)
+
+
+def _parse_read_interval(value):
+    try:
+        interval = float(value)
+    except (TypeError, ValueError) as exc:
+        raise EcoMainConfigError(
+            "read_interval must be a finite number greater than zero"
+        ) from exc
+    if not math.isfinite(interval) or interval <= 0:
+        raise EcoMainConfigError(
+            "read_interval must be a finite number greater than zero"
+        )
+    return interval
+
+
+def _parse_connection_settings(host, serial, timeout):
+    parsed_host = "" if host is None else str(host).strip()
+    if not parsed_host:
+        raise EcoMainConfigError("host must not be empty")
+
+    parsed_serial = "" if serial is None else str(serial).strip()
+    if re.fullmatch(r"[0-9]{12}", parsed_serial) is None:
+        raise EcoMainConfigError("serial must contain exactly 12 digits")
+
+    try:
+        parsed_timeout = float(str(timeout).strip())
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise EcoMainConfigError(
+            "timeout must be a finite number greater than zero"
+        ) from exc
+    if not math.isfinite(parsed_timeout) or parsed_timeout <= 0:
+        raise EcoMainConfigError(
+            "timeout must be a finite number greater than zero"
+        )
+
+    return {
+        "host": parsed_host,
+        "serial": parsed_serial,
+        "timeout": parsed_timeout,
+    }
+
+
+def _validate_device_info(info, expected_serial):
+    if not isinstance(info, Mapping):
+        raise EcoMainReadError("device info unavailable")
+
+    model = info.get("model")
+    if model != EXPECTED_MODEL:
+        raise EcoMainReadError(f"unexpected model {model!r}")
+
+    versions = info.get("versions")
+    software = (
+        versions.get("ecomain_software")
+        if isinstance(versions, Mapping)
+        else None
+    )
+    if isinstance(software, bool) or not isinstance(software, int):
+        raise EcoMainReadError("unsupported software version: unavailable")
+    if software < MINIMUM_SOFTWARE_VERSION:
+        raise EcoMainReadError(f"unsupported software version {software}")
+
+    serial = info.get("serial")
+    if serial != expected_serial:
+        raise EcoMainReadError("serial number mismatch")
+
+
+class EmonHubEcoMainInterfacer(EmonHubInterfacer):
+    def __init__(self, name, host="", serial="", timeout=3):
+        super().__init__(name)
+        self.init_settings = {
+            "host": host,
+            "serial": serial,
+            "timeout": timeout,
+        }
+        self._connection_settings = None
+        try:
+            connection_settings = _parse_connection_settings(
+                host, serial, timeout
+            )
+        except EcoMainConfigError as exc:
+            self._log.warning(
+                "Invalid %s connection configuration: %s", name, exc
+            )
+        else:
+            self.init_settings = dict(connection_settings)
+            self._connection_settings = connection_settings
+        self._settings["read_interval"] = 10.0
+        self._meters = ()
+        self._pending = deque()
+        self._client = None
+        self._reader = None
+        self._next_poll_at = 0.0
+        self._failure_count = 0
+
+    def set(self, **kwargs):
+        try:
+            read_interval = self._settings["read_interval"]
+            if "read_interval" in kwargs:
+                read_interval = _parse_read_interval(kwargs["read_interval"])
+
+            meters = self._meters
+            if "meters" in kwargs:
+                meters = _parse_meters(kwargs["meters"])
+        except EcoMainConfigError as exc:
+            self._log.warning("Invalid %s configuration: %s", self.name, exc)
+            return
+
+        parent_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in ("read_interval", "meters")
+        }
+        super().set(**parent_kwargs)
+        self._settings["read_interval"] = read_interval
+        self._meters = meters
+        if "meters" in kwargs:
+            self._pending.clear()
+
+    def _process_rx(self, cargo):
+        # Meter-local names are authoritative over global [nodes] mappings.
+        logical_nodename = cargo.nodename
+        processed = super()._process_rx(cargo)
+        if processed and logical_nodename:
+            processed.nodename = logical_nodename
+        return processed
+
+    def _connect(self):
+        settings = self._connection_settings
+        if settings is None:
+            return False
+        if ModbusTcpClient is None:
+            self._log.warning(
+                "Failed to connect %s: pymodbus is not installed",
+                self.name,
+            )
+            return False
+        try:
+            client = ModbusTcpClient(
+                host=settings["host"],
+                port=ECOMAIN_PORT,
+                timeout=settings["timeout"],
+            )
+            self._client = client
+            if not client.connect():
+                self._log.warning(
+                    "Failed to connect %s to %s:%s",
+                    self.name,
+                    settings["host"],
+                    ECOMAIN_PORT,
+                )
+                self._disconnect()
+                return False
+
+            self._reader = EcoMainReader(
+                client,
+                unit_id=ECOMAIN_UNIT_ID,
+            )
+        except Exception as exc:
+            self._log.warning("Failed to connect %s: %s", self.name, exc)
+            self._disconnect()
+            return False
+
+        try:
+            info = self._reader.read_device_info()
+            _validate_device_info(info, settings["serial"])
+        except Exception as exc:
+            self._log.warning(
+                "Connected %s but device identity validation failed: %s",
+                self.name,
+                exc,
+            )
+            self._disconnect()
+            return False
+        self._log.info("Connected %s device: %s", self.name, info)
+        return True
+
+    def _disconnect(self):
+        client = self._client
+        self._reader = None
+        self._client = None
+        if client is None:
+            return
+        try:
+            client.close()
+        except Exception as exc:
+            self._log.warning("Failed to close %s connection: %s", self.name, exc)
+
+    def _set_next_poll(self, now, succeeded):
+        if succeeded:
+            self._failure_count = 0
+            delay = self._settings["read_interval"]
+        else:
+            self._failure_count += 1
+            delay = min(10 * self._failure_count, 60)
+        self._next_poll_at = now + delay
+
+    def _poll(self, timestamp):
+        requirements = []
+        seen = set()
+        for meter in self._meters:
+            if meter["source"] == "grid":
+                requirement = ("grid", None)
+            else:
+                for phase in meter["phases"]:
+                    requirement = ("branches", phase["device"])
+                    if requirement not in seen:
+                        seen.add(requirement)
+                        requirements.append(requirement)
+                continue
+            if requirement not in seen:
+                seen.add(requirement)
+                requirements.append(requirement)
+
+        grid = None
+        branches = {}
+        succeeded = True
+        try:
+            for source, device in requirements:
+                if source == "grid":
+                    grid = self._reader.read_grid()
+                else:
+                    branches[device] = self._reader.read_branch_device(device)
+        except EcoMainReadError as exc:
+            succeeded = False
+            self._log.warning("Failed to poll %s: %s", self.name, exc)
+
+        cargos = []
+        for meter in self._meters:
+            if meter["source"] == "grid":
+                if grid is None:
+                    continue
+                cargos.append(
+                    _build_three_phase_cargo(
+                        meter,
+                        grid["phases"],
+                        timestamp,
+                        totals=grid,
+                    )
+                )
+                continue
+
+            if any(phase["device"] not in branches for phase in meter["phases"]):
+                continue
+            phases = [
+                _apply_invert(
+                    branches[phase["device"]][phase["channel"]],
+                    phase["invert"],
+                )
+                for phase in meter["phases"]
+            ]
+            if len(phases) == 1:
+                cargos.append(_build_single_phase_cargo(meter, phases[0], timestamp))
+            else:
+                cargos.append(_build_three_phase_cargo(meter, phases, timestamp))
+        return cargos, succeeded
+
+    def read(self):
+        if self._pending:
+            return self._pending.popleft()
+        if not self._meters or self._connection_settings is None:
+            return None
+
+        now = current_time()
+        if now < self._next_poll_at:
+            return None
+
+        if self._reader is None and not self._connect():
+            self._set_next_poll(current_time(), False)
+            return None
+
+        cargos, succeeded = self._poll(now)
+        if not succeeded:
+            self._disconnect()
+        self._set_next_poll(current_time(), succeeded)
+        self._pending.extend(cargos)
+        if self._pending:
+            return self._pending.popleft()
+        return None
+
+    def close(self):
+        self._disconnect()

--- a/src/interfacers/__init__.py
+++ b/src/interfacers/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "EmonHubGoodWeInterfacer",
     "EmonHubInfluxInterfacer",
     "EmonHubEconet300Interfacer",
-    "EmonHubEconextInterfacer"
+    "EmonHubEconextInterfacer",
+    "EmonHubEcoMainInterfacer",
     #"EmonFroniusModbusTcpInterfacer"
 ]

--- a/tests/test_ecomain_interfacer.py
+++ b/tests/test_ecomain_interfacer.py
@@ -1,0 +1,1552 @@
+import importlib
+import subprocess
+import sys
+import textwrap
+import unittest
+import warnings
+from unittest.mock import MagicMock, call, patch
+
+from configobj import ConfigObj
+
+import interfacers
+import emonhub_coder as ehc
+from interfacers.EmonHubEcoMainInterfacer import (
+    EcoMainConfigError,
+    EcoMainReadError,
+    EmonHubEcoMainInterfacer,
+    SINGLE_PHASE_NAMES,
+    THREE_PHASE_NAMES,
+    _apply_invert,
+    _build_single_phase_cargo,
+    _build_three_phase_cargo,
+    _parse_meters,
+    _parse_phase,
+)
+from interfacers.EmonHubMqttInterfacer import EmonHubMqttInterfacer
+
+
+EXPECTED_SERIAL = "001234567890"
+
+
+class InterfacerRegistrationTests(unittest.TestCase):
+    def test_ecomain_type_is_registered_and_importable(self):
+        type_name = "EmonHubEcoMainInterfacer"
+
+        self.assertIn(type_name, interfacers.__all__)
+        module = importlib.import_module(f"interfacers.{type_name}")
+        self.assertEqual(getattr(module, type_name).__name__, type_name)
+
+    def test_module_import_succeeds_without_pymodbus(self):
+        script = textwrap.dedent(
+            """
+            import builtins
+            import importlib
+
+            original_import = builtins.__import__
+
+            def block_pymodbus(name, *args, **kwargs):
+                if name == "pymodbus" or name.startswith("pymodbus."):
+                    raise ImportError("pymodbus intentionally unavailable")
+                return original_import(name, *args, **kwargs)
+
+            builtins.__import__ = block_pymodbus
+            module = importlib.import_module(
+                "interfacers.EmonHubEcoMainInterfacer"
+            )
+            assert module.ModbusTcpClient is None
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_module_import_supports_legacy_pymodbus_client_path(self):
+        script = textwrap.dedent(
+            """
+            import importlib
+            import sys
+            import types
+
+            pymodbus = types.ModuleType("pymodbus")
+            pymodbus.__path__ = []
+            client = types.ModuleType("pymodbus.client")
+            client.__path__ = []
+            sync = types.ModuleType("pymodbus.client.sync")
+
+            class LegacyModbusTcpClient:
+                pass
+
+            sync.ModbusTcpClient = LegacyModbusTcpClient
+            sys.modules["pymodbus"] = pymodbus
+            sys.modules["pymodbus.client"] = client
+            sys.modules["pymodbus.client.sync"] = sync
+
+            module = importlib.import_module(
+                "interfacers.EmonHubEcoMainInterfacer"
+            )
+            assert module.ModbusTcpClient is LegacyModbusTcpClient
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+def valid_meters():
+    return {
+        "grid": {
+            "nodeid": "30",
+            "nodename": "ecomain_grid",
+            "source": "grid",
+        },
+        "heatpump": {
+            "nodeid": "31",
+            "nodename": "ecomain_heatpump",
+            "source": "branches",
+            "phases": "1:4:true",
+        },
+    }
+
+
+def make_driver(**kwargs):
+    kwargs.setdefault("serial", EXPECTED_SERIAL)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"setName\(\) is deprecated, set the name attribute instead",
+            category=DeprecationWarning,
+        )
+        return EmonHubEcoMainInterfacer("EcoMain", **kwargs)
+
+
+def device_info(model="2401", software=139, serial=EXPECTED_SERIAL):
+    return {
+        "model": model,
+        "serial": serial,
+        "versions": {
+            "hardware": 1,
+            "ecomain_software": software,
+            "ecomain_firmware": 139,
+            "ecosub_1_firmware": 0,
+            "ecosub_2_firmware": 0,
+            "ecosub_3_firmware": 0,
+        },
+    }
+
+
+def branch_sample(power):
+    return {
+        "power": power,
+        "energy": power + 1.0,
+        "return_energy": power + 2.0,
+        "voltage": 230.0,
+        "current": 1.0,
+        "power_factor": 0.9,
+    }
+
+
+def branch_device(base):
+    return {channel: branch_sample(base + channel) for channel in range(1, 11)}
+
+
+def grid_sample():
+    return {
+        "power": 60.0,
+        "energy": 100.0,
+        "return_energy": 2.0,
+        "phases": [
+            {
+                "power": 10.0,
+                "voltage": 230.0,
+                "current": 1.0,
+                "power_factor": 0.91,
+            },
+            {
+                "power": 20.0,
+                "voltage": 231.0,
+                "current": 2.0,
+                "power_factor": 0.92,
+            },
+            {
+                "power": 30.0,
+                "voltage": 232.0,
+                "current": 3.0,
+                "power_factor": 0.93,
+            },
+        ],
+    }
+
+
+def branch_meters():
+    return {
+        "first": {
+            "nodeid": "41",
+            "nodename": "first",
+            "source": "branches",
+            "phases": "0:1:false",
+        },
+        "second": {
+            "nodeid": "42",
+            "nodename": "second",
+            "source": "branches",
+            "phases": "0:2:false",
+        },
+        "third": {
+            "nodeid": "43",
+            "nodename": "third",
+            "source": "branches",
+            "phases": "2:1:false",
+        },
+    }
+
+
+class PhaseParsingTests(unittest.TestCase):
+    def test_phase_parses_explicit_false(self):
+        self.assertEqual(
+            _parse_phase("0:1:false"),
+            {"device": 0, "channel": 1, "invert": False},
+        )
+
+    def test_phase_boolean_is_case_insensitive_but_not_ambiguous(self):
+        self.assertTrue(_parse_phase("3:10:TrUe")["invert"])
+        for value in ("yes", "no", "1", "0", "on", "off", ""):
+            with self.subTest(value=value):
+                with self.assertRaises(EcoMainConfigError):
+                    _parse_phase(f"0:1:{value}")
+
+    def test_phase_requires_exactly_three_fields(self):
+        for value in ("0:1", "0:1:false:extra"):
+            with self.subTest(value=value):
+                with self.assertRaises(EcoMainConfigError):
+                    _parse_phase(value)
+
+    def test_phase_rejects_device_and_channel_outside_supported_ranges(self):
+        for value in ("-1:1:false", "4:1:false", "0:0:false", "0:11:false"):
+            with self.subTest(value=value):
+                with self.assertRaises(EcoMainConfigError):
+                    _parse_phase(value)
+
+
+class MeterParsingTests(unittest.TestCase):
+    def test_empty_meters_are_rejected(self):
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters({})
+
+    def test_grid_rejects_phases_and_only_one_grid_is_allowed(self):
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters(
+                {
+                    "grid": {
+                        "nodeid": "1",
+                        "nodename": "grid",
+                        "source": "grid",
+                        "phases": "0:1:false",
+                    }
+                }
+            )
+
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters(
+                {
+                    "grid_a": {
+                        "nodeid": "1",
+                        "nodename": "grid_a",
+                        "source": "grid",
+                    },
+                    "grid_b": {
+                        "nodeid": "2",
+                        "nodename": "grid_b",
+                        "source": "grid",
+                    },
+                }
+            )
+
+    def test_branches_require_exactly_one_or_three_phases(self):
+        for phases in (None, [], ["0:1:false", "0:2:false"]):
+            meter = {
+                "nodeid": "1",
+                "nodename": "load",
+                "source": "branches",
+            }
+            if phases is not None:
+                meter["phases"] = phases
+            with self.subTest(phases=phases):
+                with self.assertRaises(EcoMainConfigError):
+                    _parse_meters({"load": meter})
+
+    def test_branches_reject_mapping_shaped_phases(self):
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters(
+                {
+                    "load": {
+                        "nodeid": "1",
+                        "nodename": "load",
+                        "source": "branches",
+                        "phases": {"0:1:false": "ignored"},
+                    }
+                }
+            )
+
+    def test_source_must_be_grid_or_branches(self):
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters(
+                {
+                    "load": {
+                        "nodeid": "1",
+                        "nodename": "load",
+                        "source": "branch",
+                        "phases": "0:1:false",
+                    }
+                }
+            )
+
+    def test_nodeid_must_be_an_integer_and_globally_unique(self):
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters(
+                {
+                    "load": {
+                        "nodeid": "1.5",
+                        "nodename": "load",
+                        "source": "branches",
+                        "phases": "0:1:false",
+                    }
+                }
+            )
+
+        meters = valid_meters()
+        meters["heatpump"]["nodeid"] = "30"
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters(meters)
+
+    def test_nodename_must_be_nonempty_and_globally_unique(self):
+        for nodename in (None, "", "   "):
+            with self.subTest(nodename=nodename):
+                with self.assertRaises(EcoMainConfigError):
+                    _parse_meters(
+                        {
+                            "load": {
+                                "nodeid": "1",
+                                "nodename": nodename,
+                                "source": "branches",
+                                "phases": "0:1:false",
+                            }
+                        }
+                    )
+
+        meters = valid_meters()
+        meters["heatpump"]["nodename"] = "ecomain_grid"
+        with self.assertRaises(EcoMainConfigError):
+            _parse_meters(meters)
+
+    def test_nodename_rejects_mqtt_or_emoncms_unsafe_characters(self):
+        for nodename in (
+            "ecomain/grid",
+            "ecomain#grid",
+            "ecomain+grid",
+            "ecomain:grid",
+        ):
+            with self.subTest(nodename=nodename):
+                with self.assertRaisesRegex(
+                    EcoMainConfigError, "contains unsupported characters"
+                ):
+                    _parse_meters(
+                        {
+                            "grid": {
+                                "nodeid": "30",
+                                "nodename": nodename,
+                                "source": "grid",
+                            }
+                        }
+                    )
+
+        parsed = _parse_meters(
+            {
+                "grid": {
+                    "nodeid": "30",
+                    "nodename": "ecoMain 测试-1.0",
+                    "source": "grid",
+                }
+            }
+        )
+        self.assertEqual(parsed[0]["nodename"], "ecoMain 测试-1.0")
+
+    def test_branch_reference_is_globally_unique(self):
+        for meters in (
+            {
+                "load": {
+                    "nodeid": "1",
+                    "nodename": "load",
+                    "source": "branches",
+                    "phases": ["0:1:false", "0:1:true", "0:2:false"],
+                }
+            },
+            {
+                "load_a": {
+                    "nodeid": "1",
+                    "nodename": "load_a",
+                    "source": "branches",
+                    "phases": "0:1:false",
+                },
+                "load_b": {
+                    "nodeid": "2",
+                    "nodename": "load_b",
+                    "source": "branches",
+                    "phases": "0:1:true",
+                },
+            },
+        ):
+            with self.subTest(meters=meters):
+                with self.assertRaises(EcoMainConfigError):
+                    _parse_meters(meters)
+
+    def test_parsed_meters_preserve_configobj_insertion_order(self):
+        meters = ConfigObj()
+        meters["heatpump"] = {
+            "nodeid": "31",
+            "nodename": "ecomain_heatpump",
+            "source": "branches",
+            "phases": "1:4:true",
+        }
+        meters["grid"] = {
+            "nodeid": "30",
+            "nodename": "ecomain_grid",
+            "source": "grid",
+        }
+
+        parsed = _parse_meters(meters)
+
+        self.assertIsInstance(parsed, tuple)
+        self.assertEqual([meter["name"] for meter in parsed], ["heatpump", "grid"])
+        self.assertEqual(
+            parsed[0],
+            {
+                "name": "heatpump",
+                "nodeid": 31,
+                "nodename": "ecomain_heatpump",
+                "source": "branches",
+                "phases": (
+                    {"device": 1, "channel": 4, "invert": True},
+                ),
+            },
+        )
+
+    def test_configobj_three_phase_list_is_applied_end_to_end(self):
+        config = ConfigObj(
+            [
+                "[meters]",
+                "[[pv]]",
+                "nodeid = 31",
+                "nodename = ecomain_pv",
+                "source = branches",
+                "phases = 0:1:false, 0:2:false, 0:3:false",
+            ]
+        )
+        driver = make_driver(host="meter.local")
+
+        driver.set(meters=config["meters"])
+
+        self.assertEqual(
+            driver._meters[0]["phases"],
+            (
+                {"device": 0, "channel": 1, "invert": False},
+                {"device": 0, "channel": 2, "invert": False},
+                {"device": 0, "channel": 3, "invert": False},
+            ),
+        )
+
+
+class CargoMappingTests(unittest.TestCase):
+    def test_invert_reverses_direction_without_changing_electrical_values(self):
+        sample = {
+            "power": 125.5,
+            "energy": 8.0,
+            "return_energy": 1.25,
+            "voltage": 231.2,
+            "current": 0.75,
+            "power_factor": 0.92,
+        }
+
+        result = _apply_invert(sample, True)
+
+        self.assertEqual(
+            result,
+            {
+                "power": -125.5,
+                "energy": 1.25,
+                "return_energy": 8.0,
+                "voltage": 231.2,
+                "current": 0.75,
+                "power_factor": -0.92,
+            },
+        )
+        self.assertEqual(sample["power"], 125.5)
+        self.assertIsNot(_apply_invert(sample, False), sample)
+
+    def test_single_phase_cargo_has_fixed_schema_and_metadata(self):
+        meter = {"nodeid": 31, "nodename": "ecomain_heatpump"}
+        sample = {
+            "power": 0.0,
+            "energy": 12.5,
+            "return_energy": 0.25,
+            "voltage": 230.0,
+            "current": 0.0,
+            "power_factor": 0.0,
+        }
+
+        cargo = _build_single_phase_cargo(meter, sample, 1725181200.25)
+
+        self.assertEqual(cargo.nodeid, 31)
+        self.assertEqual(cargo.nodename, "ecomain_heatpump")
+        self.assertEqual(cargo.names, list(SINGLE_PHASE_NAMES))
+        self.assertEqual(
+            cargo.names,
+            [
+                "power",
+                "energy",
+                "return_energy",
+                "voltage",
+                "current",
+                "power_factor",
+            ],
+        )
+        self.assertEqual(cargo.realdata, [0.0, 12.5, 0.25, 230.0, 0.0, 0.0])
+        self.assertEqual(cargo.timestamp, 1725181200.25)
+
+    def test_three_phase_branch_aggregates_post_invert_samples_and_keeps_zeros(self):
+        meter = {"nodeid": 32, "nodename": "ecomain_branch"}
+        phases = [
+            {
+                "power": 100.0,
+                "energy": 10.0,
+                "return_energy": 1.0,
+                "voltage": 230.0,
+                "current": 1.0,
+                "power_factor": 0.9,
+            },
+            _apply_invert(
+                {
+                    "power": 40.0,
+                    "energy": 7.0,
+                    "return_energy": 2.0,
+                    "voltage": 231.0,
+                    "current": 0.0,
+                    "power_factor": 0.8,
+                },
+                True,
+            ),
+            {
+                "power": 0.0,
+                "energy": 3.0,
+                "return_energy": 0.5,
+                "voltage": 229.0,
+                "current": 0.0,
+                "power_factor": 0.0,
+            },
+        ]
+
+        cargo = _build_three_phase_cargo(meter, phases, 1725181201.5)
+
+        self.assertEqual(cargo.nodeid, 32)
+        self.assertEqual(cargo.nodename, "ecomain_branch")
+        self.assertEqual(cargo.names, list(THREE_PHASE_NAMES))
+        self.assertEqual(
+            cargo.names,
+            [
+                "power",
+                "energy",
+                "return_energy",
+                "power_l1",
+                "power_l2",
+                "power_l3",
+                "voltage_l1",
+                "voltage_l2",
+                "voltage_l3",
+                "current_l1",
+                "current_l2",
+                "current_l3",
+                "power_factor_l1",
+                "power_factor_l2",
+                "power_factor_l3",
+            ],
+        )
+        self.assertEqual(
+            cargo.realdata,
+            [
+                60.0,
+                15.0,
+                8.5,
+                100.0,
+                -40.0,
+                0.0,
+                230.0,
+                231.0,
+                229.0,
+                1.0,
+                0.0,
+                0.0,
+                0.9,
+                -0.8,
+                0.0,
+            ],
+        )
+        self.assertEqual(len(cargo.names), 15)
+        self.assertEqual(len(cargo.realdata), 15)
+        self.assertEqual(cargo.timestamp, 1725181201.5)
+
+    def test_grid_cargo_preserves_protocol_totals_and_phase_order(self):
+        meter = {"nodeid": 30, "nodename": "ecomain_grid"}
+        phases = [
+            {"power": 10.0, "voltage": 230.0, "current": 1.0, "power_factor": 0.91},
+            {"power": 20.0, "voltage": 231.0, "current": 2.0, "power_factor": 0.92},
+            {"power": 30.0, "voltage": 232.0, "current": 3.0, "power_factor": 0.93},
+        ]
+        totals = {"power": 123.0, "energy": 456.0, "return_energy": 7.0}
+
+        cargo = _build_three_phase_cargo(
+            meter, phases, 1725181202.75, totals=totals
+        )
+
+        self.assertEqual(cargo.nodeid, 30)
+        self.assertEqual(cargo.nodename, "ecomain_grid")
+        self.assertEqual(cargo.names, list(THREE_PHASE_NAMES))
+        self.assertEqual(
+            cargo.realdata,
+            [
+                123.0,
+                456.0,
+                7.0,
+                10.0,
+                20.0,
+                30.0,
+                230.0,
+                231.0,
+                232.0,
+                1.0,
+                2.0,
+                3.0,
+                0.91,
+                0.92,
+                0.93,
+            ],
+        )
+        self.assertEqual(cargo.timestamp, 1725181202.75)
+
+    def test_three_phase_cargo_rejects_two_phase_samples(self):
+        meter = {"nodeid": 32, "nodename": "ecomain_branch"}
+        phase = {
+            "power": 10.0,
+            "energy": 1.0,
+            "return_energy": 0.0,
+            "voltage": 230.0,
+            "current": 1.0,
+            "power_factor": 0.9,
+        }
+
+        with self.assertRaisesRegex(
+            EcoMainConfigError, "three-phase cargo requires exactly three phases"
+        ):
+            _build_three_phase_cargo(meter, [phase, phase], 1725181203.0)
+
+    def test_three_phase_cargo_rejects_four_phase_samples(self):
+        meter = {"nodeid": 32, "nodename": "ecomain_branch"}
+        phase = {
+            "power": 10.0,
+            "energy": 1.0,
+            "return_energy": 0.0,
+            "voltage": 230.0,
+            "current": 1.0,
+            "power_factor": 0.9,
+        }
+
+        with self.assertRaisesRegex(
+            EcoMainConfigError, "three-phase cargo requires exactly three phases"
+        ):
+            _build_three_phase_cargo(meter, [phase, phase, phase, phase], 1725181203.0)
+
+
+class DataFlowIntegrationTests(unittest.TestCase):
+    def _read_two_meters(self):
+        driver = make_driver(host="meter.local")
+        driver.set(meters=valid_meters())
+        driver._client = MagicMock()
+        driver._reader = MagicMock()
+        driver._reader.read_grid.return_value = grid_sample()
+        driver._reader.read_branch_device.return_value = branch_device(10.0)
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            side_effect=[1725181300.25, 1725181300.5],
+        ):
+            first = driver.read()
+        second = driver.read()
+        return driver, first, second
+
+    def test_process_rx_preserves_each_logical_meter_metadata(self):
+        driver, first, second = self._read_two_meters()
+        original = [
+            (
+                cargo.nodeid,
+                cargo.nodename,
+                list(cargo.names),
+                list(cargo.realdata),
+                cargo.timestamp,
+            )
+            for cargo in (first, second)
+        ]
+
+        with patch.object(
+            ehc,
+            "nodelist",
+            {
+                "30": {"nodename": "global_grid"},
+                "31": {"nodename": "global_heatpump"},
+            },
+        ):
+            processed = [driver._process_rx(first), driver._process_rx(second)]
+
+        self.assertEqual(
+            [
+                (
+                    cargo.nodeid,
+                    cargo.nodename,
+                    cargo.names,
+                    cargo.realdata,
+                    cargo.timestamp,
+                )
+                for cargo in processed
+            ],
+            original,
+        )
+
+    def test_processed_cargo_uses_nodename_in_real_mqtt_topics(self):
+        driver, first, second = self._read_two_meters()
+        with patch.object(ehc, "nodelist", {}):
+            processed = [driver._process_rx(first), driver._process_rx(second)]
+
+        with patch(
+            "interfacers.EmonHubMqttInterfacer.mqtt.Client"
+        ) as client_class, warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"setName\(\) is deprecated, set the name attribute instead",
+                category=DeprecationWarning,
+            )
+            mqtt_interfacer = EmonHubMqttInterfacer("MQTT")
+        mqtt_interfacer._connected = True
+        mqtt_interfacer.set(
+            node_format_enable=0,
+            nodevar_format_enable=1,
+            nodevar_format_basetopic="emon/",
+            node_JSON_enable=0,
+        )
+        mqtt_client = client_class.return_value
+        mqtt_client.publish.return_value = (0, 1)
+
+        for cargo in processed:
+            mqtt_interfacer.add(cargo)
+
+        topics_and_payloads = [
+            (entry.args[0], entry.kwargs["payload"])
+            for entry in mqtt_client.publish.call_args_list
+        ]
+        self.assertEqual(
+            topics_and_payloads,
+            [
+                ("emon/ecomain_grid/power", "60"),
+                ("emon/ecomain_grid/energy", "100"),
+                ("emon/ecomain_grid/return_energy", "2"),
+                ("emon/ecomain_grid/power_l1", "10"),
+                ("emon/ecomain_grid/power_l2", "20"),
+                ("emon/ecomain_grid/power_l3", "30"),
+                ("emon/ecomain_grid/voltage_l1", "230"),
+                ("emon/ecomain_grid/voltage_l2", "231"),
+                ("emon/ecomain_grid/voltage_l3", "232"),
+                ("emon/ecomain_grid/current_l1", "1"),
+                ("emon/ecomain_grid/current_l2", "2"),
+                ("emon/ecomain_grid/current_l3", "3"),
+                ("emon/ecomain_grid/power_factor_l1", "0.91"),
+                ("emon/ecomain_grid/power_factor_l2", "0.92"),
+                ("emon/ecomain_grid/power_factor_l3", "0.93"),
+                ("emon/ecomain_heatpump/power", "-14"),
+                ("emon/ecomain_heatpump/energy", "16"),
+                ("emon/ecomain_heatpump/return_energy", "15"),
+                ("emon/ecomain_heatpump/voltage", "230"),
+                ("emon/ecomain_heatpump/current", "1"),
+                ("emon/ecomain_heatpump/power_factor", "-0.9"),
+            ],
+        )
+
+
+class InterfacerConfigurationTests(unittest.TestCase):
+    def test_constructor_exposes_only_device_specific_connection_settings(self):
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+        ) as client_class:
+            driver = make_driver(
+                host="meter.local", serial="001234567890", timeout="2.5"
+            )
+
+        client_class.assert_not_called()
+        self.assertEqual(
+            driver.init_settings,
+            {
+                "host": "meter.local",
+                "serial": "001234567890",
+                "timeout": 2.5,
+            },
+        )
+        self.assertIsNone(driver._client)
+        self.assertIsNone(driver._reader)
+
+    def test_serial_must_contain_exactly_twelve_digits(self):
+        invalid_serials = (
+            None,
+            "",
+            "00123456789",
+            "0012345678900",
+            "00123456789A",
+        )
+        for serial in invalid_serials:
+            with self.subTest(serial=serial), self.assertLogs(
+                "EmonHub", level="WARNING"
+            ):
+                driver = make_driver(host="meter.local", serial=serial)
+                self.assertIsNone(driver._connection_settings)
+
+        driver = make_driver(host="meter.local", serial="001234567890")
+        self.assertEqual(driver.init_settings["serial"], "001234567890")
+
+    def test_loader_raw_init_settings_do_not_replace_typed_connection_state(self):
+        config = ConfigObj(
+            [
+                "[ecoMain]",
+                "Type = EmonHubEcoMainInterfacer",
+                "[[init_settings]]",
+                "host = meter.local",
+                f"serial = {EXPECTED_SERIAL}",
+                "timeout = 2.5",
+                "[[runtimesettings]]",
+                "read_interval = 10",
+                "[[[meters]]]",
+                "[[[[grid]]]]",
+                "nodeid = 30",
+                "nodename = ecomain_grid",
+                "source = grid",
+            ]
+        )
+        settings = config["ecoMain"]
+        driver = make_driver(**settings["init_settings"])
+        driver.set(**settings["runtimesettings"])
+        driver.init_settings = settings["init_settings"]
+        client = MagicMock()
+        client.connect.return_value = True
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_grid.return_value = grid_sample()
+        reader.read_branch_device.return_value = branch_device(10.0)
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ) as reader_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            side_effect=[100.0, 100.0],
+        ):
+            cargo = driver.read()
+
+        self.assertEqual(cargo.nodeid, 30)
+        client_class.assert_called_once_with(
+            host="meter.local", port=502, timeout=2.5
+        )
+        reader_class.assert_called_once_with(client, unit_id=255)
+
+    def test_invalid_physical_settings_remain_idle_without_connecting(self):
+        invalid_settings = (
+            {"host": ""},
+            {"host": "   "},
+            {"host": None},
+            {"host": "meter.local", "timeout": "not-a-timeout"},
+            {"host": "meter.local", "timeout": "nan"},
+            {"host": "meter.local", "timeout": "inf"},
+            {"host": "meter.local", "timeout": "-inf"},
+            {"host": "meter.local", "timeout": 0},
+            {"host": "meter.local", "timeout": -1},
+        )
+
+        for settings in invalid_settings:
+            with self.subTest(settings=settings), self.assertLogs(
+                "EmonHub", level="WARNING"
+            ):
+                try:
+                    driver = make_driver(**settings)
+                except Exception as exc:
+                    self.fail(f"invalid physical settings raised {exc!r}")
+                driver.set(meters=valid_meters())
+                with patch(
+                    "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+                ) as client_class, patch(
+                    "interfacers.EmonHubEcoMainInterfacer.current_time",
+                    return_value=100.0,
+                ) as current_time:
+                    result = driver.read()
+
+                self.assertIsNone(result)
+                client_class.assert_not_called()
+                current_time.assert_not_called()
+
+    def test_valid_runtime_settings_are_applied_with_parent_settings(self):
+        driver = make_driver()
+
+        driver.set(
+            read_interval="10",
+            meters=valid_meters(),
+            pubchannels=["ToEmonCMS"],
+        )
+
+        self.assertEqual(driver._settings["read_interval"], 10.0)
+        self.assertEqual(driver._settings["pubchannels"], ["ToEmonCMS"])
+        self.assertEqual([meter["name"] for meter in driver._meters], ["grid", "heatpump"])
+
+    def test_invalid_runtime_settings_preserve_the_previous_snapshot(self):
+        driver = make_driver()
+        driver.set(
+            read_interval="10",
+            meters=valid_meters(),
+            pubchannels=["ToEmonCMS"],
+        )
+        previous = driver._meters
+        invalid_meters = valid_meters()
+        invalid_meters["heatpump"]["phases"] = "4:1:false"
+
+        with self.assertLogs("EmonHub", level="WARNING"):
+            driver.set(
+                read_interval="bad",
+                meters=invalid_meters,
+                pubchannels=["Changed"],
+            )
+
+        self.assertIs(driver._meters, previous)
+        self.assertEqual(driver._settings["read_interval"], 10.0)
+        self.assertEqual(driver._settings["pubchannels"], ["ToEmonCMS"])
+
+    def test_empty_meter_update_preserves_all_runtime_state_and_pending_cargo(self):
+        driver = make_driver(host="meter.local")
+        driver.set(
+            read_interval="10",
+            meters=valid_meters(),
+            pubchannels=["ToEmonCMS"],
+        )
+        previous_meters = driver._meters
+        pending = MagicMock()
+        driver._pending.append(pending)
+
+        with self.assertLogs("EmonHub", level="WARNING"):
+            driver.set(
+                read_interval="20",
+                meters={},
+                pubchannels=["Changed"],
+            )
+
+        self.assertIs(driver._meters, previous_meters)
+        self.assertEqual(driver._settings["read_interval"], 10.0)
+        self.assertEqual(driver._settings["pubchannels"], ["ToEmonCMS"])
+        self.assertEqual(list(driver._pending), [pending])
+
+    def test_valid_meter_update_discards_pending_cargo_from_old_snapshot(self):
+        driver = make_driver(host="meter.local")
+        driver.set(meters=valid_meters())
+        driver._pending.extend([MagicMock(), MagicMock()])
+        replacement = {
+            "renamed": {
+                "nodeid": "50",
+                "nodename": "renamed",
+                "source": "branches",
+                "phases": "0:1:false",
+            }
+        }
+
+        driver.set(meters=replacement)
+
+        self.assertEqual([meter["name"] for meter in driver._meters], ["renamed"])
+        self.assertEqual(list(driver._pending), [])
+
+    def test_read_interval_must_be_finite_and_positive(self):
+        driver = make_driver()
+        driver.set(read_interval="10", meters=valid_meters())
+        previous = driver._meters
+
+        for value in ("nan", "inf", "-inf", "0", "-1"):
+            with self.subTest(value=value):
+                with self.assertLogs("EmonHub", level="WARNING"):
+                    driver.set(read_interval=value, meters={})
+                self.assertIs(driver._meters, previous)
+                self.assertEqual(driver._settings["read_interval"], 10.0)
+
+
+class DeviceIdentityTests(unittest.TestCase):
+    def _connect_with_info(self, info):
+        driver = make_driver(
+            host="meter.local", serial=EXPECTED_SERIAL, timeout=2.5
+        )
+        client = MagicMock()
+        client.connect.return_value = True
+        reader = MagicMock()
+        reader.read_device_info.return_value = info
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ) as reader_class:
+            connected = driver._connect()
+
+        return driver, client, reader, client_class, reader_class, connected
+
+    def test_valid_identity_uses_fixed_transport_and_supported_software(self):
+        for software in (139, 140):
+            with self.subTest(software=software):
+                driver, client, _, client_class, reader_class, connected = (
+                    self._connect_with_info(device_info(software=software))
+                )
+
+                self.assertTrue(connected)
+                client_class.assert_called_once_with(
+                    host="meter.local", port=502, timeout=2.5
+                )
+                reader_class.assert_called_once_with(client, unit_id=255)
+                self.assertIs(driver._client, client)
+
+    def test_identity_validation_stops_at_first_failed_check(self):
+        cases = (
+            (
+                device_info(model="2501", software=138, serial="001234567891"),
+                "unexpected model",
+            ),
+            (
+                device_info(software=138, serial="001234567891"),
+                "unsupported software version",
+            ),
+            (device_info(serial="001234567891"), "serial number mismatch"),
+        )
+
+        for info, message in cases:
+            with self.subTest(message=message), self.assertLogs(
+                "EmonHub", level="WARNING"
+            ) as logs:
+                driver, client, _, _, _, connected = self._connect_with_info(info)
+
+            self.assertFalse(connected)
+            self.assertTrue(any(message in entry for entry in logs.output))
+            client.close.assert_called_once_with()
+            self.assertIsNone(driver._client)
+            self.assertIsNone(driver._reader)
+
+    def test_invalid_identity_never_reads_or_publishes_measurements(self):
+        driver = make_driver(host="meter.local", serial=EXPECTED_SERIAL)
+        driver.set(meters=valid_meters())
+        client = MagicMock()
+        client.connect.return_value = True
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info(model="2501")
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            side_effect=[100.0, 100.0],
+        ), self.assertLogs("EmonHub", level="WARNING"):
+            cargo = driver.read()
+
+        self.assertIsNone(cargo)
+        reader.read_grid.assert_not_called()
+        reader.read_branch_device.assert_not_called()
+        client.close.assert_called_once_with()
+        self.assertEqual(driver._failure_count, 1)
+        self.assertEqual(driver._next_poll_at, 110.0)
+
+
+class InterfacerPollingTests(unittest.TestCase):
+    def setUp(self):
+        self.driver = make_driver(host="meter.local", timeout=2.5)
+
+    def test_first_due_read_connects_lazily_and_reads_device_info_once(self):
+        self.driver.set(meters=valid_meters())
+        client = MagicMock()
+        client.connect.return_value = True
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_grid.return_value = grid_sample()
+        reader.read_branch_device.return_value = branch_device(10.0)
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ) as reader_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            return_value=100.0,
+        ), self.assertLogs("EmonHub", level="INFO") as logs:
+            first = self.driver.read()
+            second = self.driver.read()
+
+        client_class.assert_called_once_with(
+            host="meter.local", port=502, timeout=2.5
+        )
+        client.connect.assert_called_once_with()
+        reader_class.assert_called_once_with(client, unit_id=255)
+        reader.read_device_info.assert_called_once_with()
+        self.assertTrue(
+            any("EcoMain" in line and EXPECTED_SERIAL in line for line in logs.output)
+        )
+        self.assertEqual(first.nodeid, 30)
+        self.assertEqual(second.nodeid, 31)
+        self.assertEqual(first.timestamp, 100.0)
+        self.assertEqual(second.timestamp, 100.0)
+        reader.read_grid.assert_called_once_with()
+        reader.read_branch_device.assert_called_once_with(1)
+
+    def test_pending_cargo_is_drained_before_clock_or_network_access(self):
+        self.driver.set(meters=valid_meters())
+        pending = MagicMock()
+        self.driver._pending.append(pending)
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time"
+        ) as current_time, patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+        ) as client_class:
+            result = self.driver.read()
+
+        self.assertIs(result, pending)
+        current_time.assert_not_called()
+        client_class.assert_not_called()
+
+    def test_read_before_deadline_is_idle_without_sleep_or_network(self):
+        self.driver.set(meters=valid_meters())
+        self.driver._next_poll_at = 101.0
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time", return_value=100.0
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.time.sleep",
+            side_effect=AssertionError("read must not sleep"),
+        ) as sleeper, patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+        ) as client_class:
+            result = self.driver.read()
+
+        self.assertIsNone(result)
+        sleeper.assert_not_called()
+        client_class.assert_not_called()
+
+    def test_poll_reads_only_ordered_unique_sources(self):
+        meters = branch_meters()
+        meters["grid"] = {
+            "nodeid": "44",
+            "nodename": "grid",
+            "source": "grid",
+        }
+        self.driver.set(meters=meters)
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_branch_device.side_effect = [
+            branch_device(10.0),
+            branch_device(20.0),
+        ]
+        reader.read_grid.return_value = grid_sample()
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time", return_value=100.0
+        ):
+            client_class.return_value.connect.return_value = True
+            cargos = [self.driver.read() for _ in range(4)]
+
+        self.assertEqual([cargo.nodeid for cargo in cargos], [41, 42, 43, 44])
+        self.assertEqual(
+            reader.mock_calls,
+            [
+                call.read_device_info(),
+                call.read_branch_device(0),
+                call.read_branch_device(2),
+                call.read_grid(),
+            ],
+        )
+
+    def test_branch_selection_and_invert_are_reflected_in_final_realdata(self):
+        self.driver.set(
+            meters={
+                "inverted": {
+                    "nodeid": "45",
+                    "nodename": "inverted",
+                    "source": "branches",
+                    "phases": "2:4:true",
+                }
+            }
+        )
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_branch_device.return_value = branch_device(20.0)
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            return_value=100.0,
+        ):
+            client_class.return_value.connect.return_value = True
+            cargo = self.driver.read()
+
+        reader.read_branch_device.assert_called_once_with(2)
+        self.assertEqual(cargo.names, list(SINGLE_PHASE_NAMES))
+        self.assertEqual(cargo.realdata, [-24.0, 26.0, 25.0, 230.0, 1.0, -0.9])
+
+    def test_device_info_failure_blocks_measurements(self):
+        self.driver.set(meters=valid_meters())
+        reader = MagicMock()
+        reader.read_device_info.side_effect = RuntimeError("info unavailable")
+        reader.read_grid.return_value = grid_sample()
+        reader.read_branch_device.return_value = branch_device(10.0)
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time", return_value=100.0
+        ), self.assertLogs("EmonHub", level="WARNING"):
+            client_class.return_value.connect.return_value = True
+            cargo = self.driver.read()
+
+        self.assertIsNone(cargo)
+        reader.read_grid.assert_not_called()
+        client_class.return_value.close.assert_called_once_with()
+
+    def test_close_is_idempotent_and_clears_connection_state(self):
+        client = MagicMock()
+        self.driver._client = client
+        self.driver._reader = MagicMock()
+
+        self.driver.close()
+        self.driver.close()
+
+        client.close.assert_called_once_with()
+        self.assertIsNone(self.driver._client)
+        self.assertIsNone(self.driver._reader)
+
+
+class InterfacerFailureTests(unittest.TestCase):
+    def setUp(self):
+        self.driver = make_driver(host="meter.local")
+
+    def _read_with(self, now, reader, connect_result=True):
+        client = MagicMock()
+        client.connect.return_value = connect_result
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time", return_value=now
+        ):
+            result = self.driver.read()
+        return result, client
+
+    def test_failure_publishes_only_meters_completed_before_failed_group(self):
+        self.driver.set(meters=branch_meters())
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_branch_device.side_effect = [
+            branch_device(10.0),
+            EcoMainReadError("device 2 failed"),
+        ]
+
+        first, client = self._read_with(100.0, reader)
+        second = self.driver.read()
+
+        self.assertEqual(first.nodeid, 41)
+        self.assertEqual(second.nodeid, 42)
+        self.assertEqual(first.timestamp, 100.0)
+        self.assertEqual(second.timestamp, 100.0)
+        self.assertEqual(reader.read_branch_device.call_args_list, [call(0), call(2)])
+        client.close.assert_called_once_with()
+        self.assertIsNone(self.driver._client)
+        self.assertIsNone(self.driver._reader)
+        self.assertEqual(self.driver._failure_count, 1)
+        self.assertEqual(self.driver._next_poll_at, 110.0)
+
+    def test_failure_skips_partial_meter_and_stops_before_later_source(self):
+        self.driver.set(
+            meters={
+                "complete": {
+                    "nodeid": "41",
+                    "nodename": "complete",
+                    "source": "branches",
+                    "phases": "0:1:false",
+                },
+                "spanning": {
+                    "nodeid": "42",
+                    "nodename": "spanning",
+                    "source": "branches",
+                    "phases": [
+                        "0:2:false",
+                        "1:1:false",
+                        "1:2:false",
+                    ],
+                },
+                "later": {
+                    "nodeid": "43",
+                    "nodename": "later",
+                    "source": "branches",
+                    "phases": "3:1:false",
+                },
+            }
+        )
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_branch_device.side_effect = [
+            branch_device(10.0),
+            EcoMainReadError("device 1 failed"),
+            branch_device(30.0),
+        ]
+
+        first, _ = self._read_with(100.0, reader)
+
+        self.assertEqual(first.nodeid, 41)
+        self.assertEqual(list(self.driver._pending), [])
+        self.assertEqual(reader.read_branch_device.call_args_list, [call(0), call(1)])
+
+    def test_poll_reconnects_after_backoff_with_fresh_info_and_measurements(self):
+        self.driver.set(
+            meters={
+                "load": {
+                    "nodeid": "41",
+                    "nodename": "load",
+                    "source": "branches",
+                    "phases": "0:1:false",
+                }
+            }
+        )
+        first_client = MagicMock()
+        first_client.connect.return_value = True
+        second_client = MagicMock()
+        second_client.connect.return_value = True
+        first_reader = MagicMock()
+        first_reader.read_device_info.return_value = device_info()
+        first_reader.read_branch_device.side_effect = EcoMainReadError("offline")
+        second_reader = MagicMock()
+        second_reader.read_device_info.return_value = device_info()
+        second_reader.read_branch_device.return_value = branch_device(20.0)
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            side_effect=[first_client, second_client],
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            side_effect=[first_reader, second_reader],
+        ) as reader_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            side_effect=[100.0, 100.0, 111.0, 111.0],
+        ):
+            failed = self.driver.read()
+            recovered = self.driver.read()
+
+        self.assertIsNone(failed)
+        self.assertEqual(recovered.nodeid, 41)
+        self.assertEqual(recovered.timestamp, 111.0)
+        self.assertEqual(recovered.realdata[0], 21.0)
+        self.assertEqual(client_class.call_count, 2)
+        self.assertEqual(
+            reader_class.call_args_list,
+            [call(first_client, unit_id=255), call(second_client, unit_id=255)],
+        )
+        first_reader.read_device_info.assert_called_once_with()
+        second_reader.read_device_info.assert_called_once_with()
+        first_reader.read_branch_device.assert_called_once_with(0)
+        second_reader.read_branch_device.assert_called_once_with(0)
+        first_client.close.assert_called_once_with()
+        self.assertIs(self.driver._client, second_client)
+        self.assertIs(self.driver._reader, second_reader)
+        self.assertEqual(self.driver._failure_count, 0)
+        self.assertEqual(self.driver._next_poll_at, 121.0)
+
+    def test_failed_group_never_reuses_a_previous_poll_sample(self):
+        meters = {
+            "load": {
+                "nodeid": "41",
+                "nodename": "load",
+                "source": "branches",
+                "phases": "0:1:false",
+            }
+        }
+        self.driver.set(read_interval=1, meters=meters)
+        successful_reader = MagicMock()
+        successful_reader.read_device_info.return_value = device_info()
+        successful_reader.read_branch_device.return_value = branch_device(10.0)
+        first, _ = self._read_with(100.0, successful_reader)
+        self.driver._disconnect()
+        failing_reader = MagicMock()
+        failing_reader.read_device_info.return_value = device_info()
+        failing_reader.read_branch_device.side_effect = EcoMainReadError("failed")
+
+        second, _ = self._read_with(101.0, failing_reader)
+
+        self.assertEqual(first.nodeid, 41)
+        self.assertIsNone(second)
+
+    def test_connect_false_and_exception_use_the_same_capped_backoff(self):
+        self.driver.set(meters=valid_meters())
+
+        for failure_count in range(1, 8):
+            now = float(failure_count * 100)
+            client = MagicMock()
+            if failure_count % 2:
+                client.connect.return_value = False
+            else:
+                client.connect.side_effect = OSError("offline")
+            with patch(
+                "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+                return_value=client,
+            ), patch(
+                "interfacers.EmonHubEcoMainInterfacer.current_time", return_value=now
+            ):
+                result = self.driver.read()
+
+            self.assertIsNone(result)
+            self.assertEqual(self.driver._failure_count, failure_count)
+            self.assertEqual(
+                self.driver._next_poll_at,
+                now + min(10 * failure_count, 60),
+            )
+            self.driver._next_poll_at = 0.0
+
+    def test_success_after_failure_resets_backoff_and_uses_read_interval(self):
+        self.driver.set(read_interval=7.5, meters=valid_meters())
+        self.driver._failure_count = 4
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_grid.return_value = grid_sample()
+        reader.read_branch_device.return_value = branch_device(10.0)
+
+        cargo, _ = self._read_with(200.0, reader)
+
+        self.assertEqual(cargo.nodeid, 30)
+        self.assertEqual(self.driver._failure_count, 0)
+        self.assertEqual(self.driver._next_poll_at, 207.5)
+
+    def test_failed_connect_backoff_starts_when_slow_attempt_completes(self):
+        self.driver.set(meters=valid_meters())
+        client = MagicMock()
+        client.connect.return_value = False
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            side_effect=[100.0, 107.0],
+        ):
+            result = self.driver.read()
+
+        self.assertIsNone(result)
+        self.assertEqual(self.driver._next_poll_at, 117.0)
+
+    def test_failed_read_backoff_starts_when_slow_attempt_completes(self):
+        self.driver.set(meters=branch_meters())
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_branch_device.side_effect = [
+            branch_device(10.0),
+            EcoMainReadError("device 2 failed"),
+        ]
+        client = MagicMock()
+        client.connect.return_value = True
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            side_effect=[100.0, 108.0],
+        ):
+            cargo = self.driver.read()
+
+        self.assertEqual(cargo.timestamp, 100.0)
+        self.assertEqual(self.driver._next_poll_at, 118.0)
+
+    def test_success_interval_starts_when_slow_poll_completes(self):
+        self.driver.set(read_interval=7.5, meters=valid_meters())
+        reader = MagicMock()
+        reader.read_device_info.return_value = device_info()
+        reader.read_grid.return_value = grid_sample()
+        reader.read_branch_device.return_value = branch_device(10.0)
+        client = MagicMock()
+        client.connect.return_value = True
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient",
+            return_value=client,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.EcoMainReader",
+            return_value=reader,
+        ), patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time",
+            side_effect=[100.0, 106.0],
+        ):
+            cargo = self.driver.read()
+
+        self.assertEqual(cargo.timestamp, 100.0)
+        self.assertEqual(self.driver._next_poll_at, 113.5)
+
+    def test_initial_empty_meter_snapshot_never_connects_or_checks_time(self):
+
+        with patch(
+            "interfacers.EmonHubEcoMainInterfacer.ModbusTcpClient"
+        ) as client_class, patch(
+            "interfacers.EmonHubEcoMainInterfacer.current_time"
+        ) as current_time:
+            result = self.driver.read()
+
+        self.assertIsNone(result)
+        client_class.assert_not_called()
+        current_time.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ecomain_protocol.py
+++ b/tests/test_ecomain_protocol.py
@@ -1,0 +1,306 @@
+import unittest
+
+from ecomain.protocol import (
+    EcoMainReadError,
+    EcoMainReader,
+    branch_addresses,
+    decode_i16,
+    decode_i32,
+    decode_text,
+    decode_u16,
+    decode_u64,
+)
+
+
+def words_little(value, word_count):
+    return [(value >> (16 * index)) & 0xFFFF for index in range(word_count)]
+
+
+class FakeResponse:
+    def __init__(self, registers, error=False):
+        self.registers = registers
+        self._error = error
+
+    def isError(self):
+        return self._error
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self.responses = dict(responses)
+        self.calls = []
+
+    def read_holding_registers(self, address, count, slave):
+        self.calls.append((address, count, slave))
+        return self.responses[(address, count)]
+
+
+class AddressTests(unittest.TestCase):
+    def test_branch_addresses_are_zero_based(self):
+        self.assertEqual(
+            branch_addresses(0, 1),
+            {
+                "energy": 32,
+                "return_energy": 192,
+                "power": 1008,
+                "voltage": 1209,
+                "current": 1210,
+                "power_factor": 1211,
+            },
+        )
+        self.assertEqual(branch_addresses(3, 10)["energy"], 188)
+        self.assertEqual(branch_addresses(3, 10)["power_factor"], 1328)
+
+    def test_branch_address_range_is_validated(self):
+        for device, channel in [(-1, 1), (4, 1), (0, 0), (0, 11)]:
+            with self.subTest(device=device, channel=channel):
+                with self.assertRaises(ValueError):
+                    branch_addresses(device, channel)
+
+
+class DecoderTests(unittest.TestCase):
+    def test_numeric_decoders_use_big_bytes_little_words(self):
+        self.assertEqual(decode_u16([0x1234]), 0x1234)
+        self.assertEqual(decode_i16([0xFF9C]), -100)
+        self.assertEqual(decode_i32([0x5678, 0x1234]), 0x12345678)
+        self.assertEqual(
+            decode_u64([0xDEF0, 0x9ABC, 0x5678, 0x1234]),
+            0x123456789ABCDEF0,
+        )
+
+    def test_text_uses_low_byte_then_high_byte_per_register(self):
+        self.assertEqual(decode_text([0x4241, 0x0043]), "ABC")
+
+
+class ReaderTests(unittest.TestCase):
+    def assert_sample_almost_equal(self, sample, expected):
+        self.assertEqual(set(sample), set(expected))
+        for name, value in expected.items():
+            self.assertAlmostEqual(sample[name], value)
+
+    def test_read_uses_unit_keyword_for_legacy_client(self):
+        class LegacyClient:
+            def __init__(self):
+                self.kwargs = None
+
+            def read_holding_registers(self, address, count=1, **kwargs):
+                self.kwargs = kwargs
+                return FakeResponse([123])
+
+        client = LegacyClient()
+
+        registers = EcoMainReader(client)._read(10, 1)
+
+        self.assertEqual(registers, [123])
+        self.assertEqual(client.kwargs, {"unit": 255})
+
+    def test_read_uses_device_id_keyword_for_modern_client(self):
+        class ModernClient:
+            def __init__(self):
+                self.device_id = None
+
+            def read_holding_registers(
+                self, address, *, count=1, device_id=1, no_response_expected=False
+            ):
+                self.device_id = device_id
+                return FakeResponse([456])
+
+        client = ModernClient()
+
+        registers = EcoMainReader(client)._read(10, 1)
+
+        self.assertEqual(registers, [456])
+        self.assertEqual(client.device_id, 255)
+
+    def test_read_grid_decodes_three_exact_read_only_blocks(self):
+        energy = []
+        for value in (1_000_000, 2_000_000, 3_000_000, 6_000_000):
+            energy.extend(words_little(value, 4))
+        for value in (100_000, 200_000, 300_000, 600_000):
+            energy.extend(words_little(value, 4))
+
+        power = []
+        for value in (12_345, -2_500, 3_000, 12_845):
+            power.extend(words_little(value, 2))
+
+        electric = [23001, 123, 98, 23002, 456, 0xFF9C, 22999, 789, 100]
+        client = FakeClient(
+            {
+                (0, 32): FakeResponse(energy),
+                (1000, 8): FakeResponse(power),
+                (1200, 9): FakeResponse(electric),
+            }
+        )
+
+        sample = EcoMainReader(client).read_grid()
+
+        self.assertEqual(set(sample), {"power", "energy", "return_energy", "phases"})
+        self.assert_sample_almost_equal(
+            {name: sample[name] for name in ("power", "energy", "return_energy")},
+            {"power": 128.45, "energy": 6.0, "return_energy": 0.6},
+        )
+        expected_phases = (
+            {
+                "power": 123.45,
+                "voltage": 230.01,
+                "current": 1.23,
+                "power_factor": 0.98,
+            },
+            {
+                "power": -25.0,
+                "voltage": 230.02,
+                "current": 4.56,
+                "power_factor": -1.0,
+            },
+            {
+                "power": 30.0,
+                "voltage": 229.99,
+                "current": 7.89,
+                "power_factor": 1.0,
+            },
+        )
+        self.assertEqual(len(sample["phases"]), 3)
+        for phase, expected in zip(sample["phases"], expected_phases):
+            self.assert_sample_almost_equal(phase, expected)
+        self.assertEqual(
+            client.calls,
+            [(0, 32, 255), (1000, 8, 255), (1200, 9, 255)],
+        )
+
+    def test_read_branch_device_decodes_ten_channels_from_four_blocks(self):
+        forward = []
+        reverse = []
+        power = []
+        electric = []
+        for channel in range(1, 11):
+            forward.extend(words_little(channel * 1_000_000, 4))
+            reverse.extend(words_little(channel * 100_000, 4))
+            power.extend(words_little(-channel * 100, 2))
+            electric.extend((22000 + channel, channel * 10, 100 - channel))
+        client = FakeClient(
+            {
+                (112, 40): FakeResponse(forward),
+                (272, 40): FakeResponse(reverse),
+                (1048, 20): FakeResponse(power),
+                (1269, 30): FakeResponse(electric),
+            }
+        )
+
+        samples = EcoMainReader(client).read_branch_device(2)
+
+        self.assertEqual(list(samples), list(range(1, 11)))
+        self.assert_sample_almost_equal(
+            samples[1],
+            {
+                "power": -1.0,
+                "energy": 1.0,
+                "return_energy": 0.1,
+                "voltage": 220.01,
+                "current": 0.1,
+                "power_factor": 0.99,
+            },
+        )
+        self.assert_sample_almost_equal(
+            samples[10],
+            {
+                "power": -10.0,
+                "energy": 10.0,
+                "return_energy": 1.0,
+                "voltage": 220.1,
+                "current": 1.0,
+                "power_factor": 0.9,
+            },
+        )
+        self.assertEqual(
+            client.calls,
+            [
+                (112, 40, 255),
+                (272, 40, 255),
+                (1048, 20, 255),
+                (1269, 30, 255),
+            ],
+        )
+
+    def test_read_device_info_decodes_text_and_six_version_registers(self):
+        registers = [
+            0x4345,
+            0x3130,
+            0x4E53,
+            0x3231,
+            0x3433,
+            0x3635,
+            0x3837,
+            0x3039,
+            101,
+            102,
+            103,
+            104,
+            105,
+            106,
+        ]
+        client = FakeClient({(3000, 14): FakeResponse(registers)})
+
+        info = EcoMainReader(client).read_device_info()
+
+        self.assertEqual(
+            info,
+            {
+                "model": "EC01",
+                "serial": "SN1234567890",
+                "versions": {
+                    "hardware": 101,
+                    "ecomain_software": 102,
+                    "ecomain_firmware": 103,
+                    "ecosub_1_firmware": 104,
+                    "ecosub_2_firmware": 105,
+                    "ecosub_3_firmware": 106,
+                },
+            },
+        )
+        self.assertEqual(client.calls, [(3000, 14, 255)])
+
+    def test_read_rejects_error_missing_and_wrong_length_responses(self):
+        class MissingRegistersResponse:
+            def isError(self):
+                return False
+
+        for response in (
+            FakeResponse([0] * 32, error=True),
+            MissingRegistersResponse(),
+            FakeResponse([0] * 31),
+            FakeResponse([0] * 33),
+        ):
+            with self.subTest(response=response):
+                client = FakeClient({(0, 32): response})
+                with self.assertRaises(EcoMainReadError):
+                    EcoMainReader(client).read_grid()
+
+    def test_reader_wraps_client_read_errors(self):
+        client = FakeClient({})
+
+        with self.assertRaises(EcoMainReadError) as raised:
+            EcoMainReader(client).read_grid()
+
+        self.assertIsInstance(raised.exception.__cause__, KeyError)
+
+    def test_reader_never_reads_online_status_registers(self):
+        energy = FakeResponse([0] * 32)
+        power = FakeResponse([0] * 8)
+        electric = FakeResponse([0] * 9)
+        info = FakeResponse([0] * 14)
+        client = FakeClient(
+            {
+                (0, 32): energy,
+                (1000, 8): power,
+                (1200, 9): electric,
+                (3000, 14): info,
+            }
+        )
+        reader = EcoMainReader(client)
+
+        reader.read_grid()
+        reader.read_device_info()
+
+        self.assertTrue(
+            all(address not in (3101, 3102, 3103) for address, _, _ in client.calls)
+        )


### PR DESCRIPTION
## Overview

Hello OpenEnergyMonitor team,

We are the enecess team. First of all, thank you for your continued work on OpenEnergyMonitor and its open energy monitoring ecosystem.

We would like to contribute a Modbus TCP integration for ecoMain to emonHub.

ecoMain can measure a three-phase main circuit and 10 branch circuits. Up to three ecoSub units can be added, extending the system to a total of 40 branch circuits. The new `EmonHubEcoMainInterfacer` reads these measurements and publishes them to Emoncms through the existing emonHub data flow.

## Main features

- Read power, voltage, current, power factor, and imported and exported cumulative active energy from the three-phase main circuit
- Configure ecoMain or ecoSub branch circuits as single-phase or three-phase logical meters
- Correct the current transformer installation direction for individual phases
- Publish measurements to Emoncms using the configured node names
- Include an example configuration, English documentation, and automated tests

The integration is strictly read-only and only uses Modbus function code `03`. It does not write registers, change device settings, or control external devices. It also does not change the behavior of the emonHub core framework.

## Validation

- 67 automated tests pass
- Tested with real ecoMain hardware and Emoncms running on a Raspberry Pi
- Measurements are displayed correctly and continuously updated on the Emoncms Inputs page

## Documentation

- [ecoMain product page](https://www.enecess.eu/de/products/ecomain)
- [ecoMain user manual](https://cdn.shopify.com/s/files/1/0759/6287/6072/files/ecoMain_User_Manual_EN.pdf?v=1784192565)
- [ecoMain Modbus communication manual](https://cdn.shopify.com/s/files/1/0759/6287/6072/files/ecoMain_Modbus_Communication_Manual_EN.pdf?v=1787823654)

Thank you for taking the time to review this pull request. We welcome your feedback and are happy to refine the implementation in line with emonHub's project conventions.
